### PR TITLE
Add type aliases OptionalUnset[T] and OptionalUnsetNone[T]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for class inheritance of validataclasses, e.g. extend an existing validataclass by adding new fields or setting a
   different default value for an existing field. ([#10](https://github.com/binary-butterfly/validataclass/issues/10))
+- Type alias `OptionalUnset[T]` as a shortcut for `Union[T, UnsetValueType]`
+- Type alias `OptionalUnsetNone[T]` as a shortcut for `OptionalUnset[Optional[T]]` (or `Union[T, NoneType, UnsetValueType]`)
 
 ### Changed
 

--- a/docs/05-dataclasses.md
+++ b/docs/05-dataclasses.md
@@ -431,7 +431,9 @@ in your code to distinguish it from other values like `None`.
 
 For this you can use the `DefaultUnset` object, which is a shortcut for `Default(UnsetValue)`.
 
-Remember to adjust the type hints in your dataclass though. For example: `some_var: Union[int, UnsetValueType]`.
+Remember to adjust the type hints in your dataclass though. There is a type alias `OptionalUnset[T]` which you can use for this, for
+example: `some_var: OptionalUnset[int]`, which is equivalent to `Union[int, UnsetValueType]`. For fields that can be both `None` and
+`UnsetValue`, there is also the type alias `OptionalUnsetNone[T]` as a shortcut for `OptionalUnset[Optional[T]]`.
 
 
 #### NoDefault
@@ -449,17 +451,17 @@ The following code contains examples for all the various `Default` classes that 
 
 ```python
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional
 
-from validataclass.helpers import validataclass, Default, DefaultUnset, DefaultFactory, UnsetValueType, NoDefault
+from validataclass.helpers import validataclass, Default, DefaultUnset, DefaultFactory, NoDefault, OptionalUnset
 from validataclass.validators import IntegerValidator, ListValidator, DateTimeValidator
 
 @validataclass
 class ExampleClass:
     # Simple defaults for integer fields
-    field_a: int = IntegerValidator(), Default(42)                          # Default value is 42
-    field_b: Optional[int] = IntegerValidator(), Default(None)              # Default value is None
-    field_c: Union[int, UnsetValueType] = IntegerValidator(), DefaultUnset  # Default value is UnsetValue
+    field_a: int = IntegerValidator(), Default(42)                  # Default value is 42
+    field_b: Optional[int] = IntegerValidator(), Default(None)      # Default value is None
+    field_c: OptionalUnset[int] = IntegerValidator(), DefaultUnset  # Default value is UnsetValue
     
     # Defaults for lists
     field_d: list = ListValidator(IntegerValidator()), Default([])  # Default value is an empty list
@@ -543,7 +545,7 @@ the "modify" dataclass from the "create" dataclass and change all field defaults
 from decimal import Decimal
 from typing import Optional, Union
 
-from validataclass.helpers import validataclass, Default, DefaultUnset, UnsetValueType
+from validataclass.helpers import validataclass, Default, DefaultUnset, OptionalUnset, OptionalUnsetNone
 from validataclass.validators import IntegerValidator, StringValidator, DecimalValidator
 
 @validataclass
@@ -555,9 +557,9 @@ class CreateStuffRequest:
 @validataclass
 class ModifyStuffRequest(CreateStuffRequest):
     # Set all field defaults to DefaultUnset
-    name: Union[str, UnsetValueType] = DefaultUnset
-    some_value: Union[int, UnsetValueType] = DefaultUnset
-    some_decimal: Union[Optional[Decimal], UnsetValueType] = DefaultUnset
+    name: OptionalUnset[str] = DefaultUnset
+    some_value: OptionalUnset[int] = DefaultUnset
+    some_decimal: OptionalUnsetNone[Decimal] = DefaultUnset
 ```
 
 As you can see here, no validators are specified in the subclass, so the `DataclassValidator` will use the same validators as for the

--- a/src/validataclass/helpers/__init__.py
+++ b/src/validataclass/helpers/__init__.py
@@ -7,4 +7,4 @@ Use of this source code is governed by an MIT-style license that can be found in
 from .dataclass_defaults import Default, DefaultFactory, DefaultUnset, NoDefault
 from .dataclasses import validataclass, validataclass_field
 from .datetime_range import BaseDateTimeRange, DateTimeRange, DateTimeOffsetRange
-from .unset_value import UnsetValue, UnsetValueType
+from .unset_value import UnsetValue, UnsetValueType, OptionalUnset, OptionalUnsetNone

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -4,7 +4,14 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-__all__ = ['UnsetValue', 'UnsetValueType']
+from typing import TypeVar, Union, Optional
+
+__all__ = [
+    'UnsetValue',
+    'UnsetValueType',
+    'OptionalUnset',
+    'OptionalUnsetNone',
+]
 
 
 # Class to create the UnsetValue sentinel object
@@ -33,3 +40,11 @@ class UnsetValueType:
 # Create sentinel object and redefine __new__ so that the object cannot be cloned
 UnsetValue = UnsetValueType()
 UnsetValueType.__new__ = lambda cls: UnsetValue
+
+
+# Type alias OptionalUnset[T] for fields with DefaultUnset (similar to Optional[T] but using UnsetValueType instead of NoneType)
+T = TypeVar('T')
+OptionalUnset = Union[T, UnsetValueType]
+
+# Type alias OptionalUnsetNone[T] for fields that can be None or UnsetValue (equivalent to OptionalUnset[Optional[T]])
+OptionalUnsetNone = OptionalUnset[Optional[T]]

--- a/tests/helpers/dataclasses_test.py
+++ b/tests/helpers/dataclasses_test.py
@@ -5,11 +5,11 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 import dataclasses
-from typing import Optional, Any, Union
+from typing import Optional, Any
 import pytest
 
 from validataclass.exceptions import DataclassValidatorFieldException
-from validataclass.helpers import validataclass, validataclass_field, Default, NoDefault, DefaultUnset, UnsetValueType
+from validataclass.helpers import validataclass, validataclass_field, Default, NoDefault, DefaultUnset, OptionalUnset
 from validataclass.validators import IntegerValidator, StringValidator, Noneable
 
 
@@ -207,7 +207,7 @@ class ValidatorDataclassTest:
             optional1: Optional[int] = (IntegerValidator(), Default(None))
             optional2: Optional[int] = (IntegerValidator(), Default(None))
             optional3: int = (IntegerValidator(), Default(3))
-            optional4: Union[UnsetValueType, int] = (IntegerValidator(), DefaultUnset)
+            optional4: OptionalUnset[int] = (IntegerValidator(), DefaultUnset)
 
         @validataclass
         class SubClass(BaseClass):
@@ -218,11 +218,11 @@ class ValidatorDataclassTest:
             # Required fields that are optional now
             required2: int = Default(42)
             required3: Optional[int] = Default(None)
-            required4: Union[UnsetValueType, int] = DefaultUnset
+            required4: OptionalUnset[int] = DefaultUnset
 
             # Optional fields that are required now or have new defaults
             optional2: int = NoDefault
-            optional3: Union[UnsetValueType, int] = DefaultUnset
+            optional3: OptionalUnset[int] = DefaultUnset
             optional4: int = Default(42)
 
         # Get fields from dataclass
@@ -235,7 +235,7 @@ class ValidatorDataclassTest:
         # Check type annotations
         assert all(fields[field].type is int for field in ['required1', 'required2', 'optional2', 'optional4'])
         assert all(fields[field].type is Optional[int] for field in ['required3', 'optional1'])
-        assert all(fields[field].type is Union[UnsetValueType, int] for field in ['required4', 'optional3'])
+        assert all(fields[field].type is OptionalUnset[int] for field in ['required4', 'optional3'])
 
         # Check validators
         assert all(type(field.metadata.get('validator')) is IntegerValidator for field in fields.values())

--- a/tests/validators/dataclass_validator_test.py
+++ b/tests/validators/dataclass_validator_test.py
@@ -6,12 +6,12 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from dataclasses import dataclass, field
 from decimal import Decimal
-from typing import Optional, Union
+from typing import Optional
 import pytest
 
 from validataclass.exceptions import ValidationError, RequiredValueError, DictFieldsValidationError, DataclassPostValidationError, \
     InternalValidationError, InvalidValidatorOptionException, DataclassValidatorFieldException
-from validataclass.helpers import validataclass, validataclass_field, Default, DefaultFactory, DefaultUnset, UnsetValue, UnsetValueType
+from validataclass.helpers import validataclass, validataclass_field, Default, DefaultFactory, DefaultUnset, UnsetValue, OptionalUnset
 from validataclass.validators import DataclassValidator, DecimalValidator, IntegerValidator, StringValidator
 
 
@@ -158,7 +158,7 @@ class DataclassValidatorTest:
         class DataclassWithDefaults:
             foo: str = (StringValidator(), Default('example default'))
             bar: int = (IntegerValidator(), DefaultFactory(counter))
-            baz: Union[UnsetValueType, str] = (StringValidator(), DefaultUnset)
+            baz: OptionalUnset[str] = (StringValidator(), DefaultUnset)
 
         validator: DataclassValidator[DataclassWithDefaults] = DataclassValidator(DataclassWithDefaults)
 


### PR DESCRIPTION
This PR adds two type aliases related to `UnsetValueType` for convenience:

- `OptionalUnset[T]` == `Union[T, UnsetValueType]` \
  (used for fields with `DefaultUnset`)
- `OptionalUnsetNone[T]` == `OptionalUnset[Optional[T]]` == `Union[T, NoneType, UnsetValueType]` \
  (used for fields that can be both None and UnsetValue, e.g. a `Noneable` field with `DefaultUnset`)