### PR TITLE
Allow empty dataclasses and detect missing annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+[Full changelog](https://github.com/binary-butterfly/validataclass/compare/0.3.0...HEAD)
+
+### Changed
+
+- `@validataclass` decorator detects fields with validator but without type annotations and will raise errors about that now.
+  [#26](https://github.com/binary-butterfly/validataclass/issues/26)
+
+### Fixed
+
+- `@validataclass` allows empty dataclasses now (raised an AttributeError before).
+  [#26](https://github.com/binary-butterfly/validataclass/issues/26) 
+
+
 ## [0.3.0](https://github.com/binary-butterfly/validataclass/releases/tag/0.3.0) - 2021-11-10
 
 [Full changelog](https://github.com/binary-butterfly/validataclass/compare/0.2.0...0.3.0)

--- a/tests/validators/dict_validator_test.py
+++ b/tests/validators/dict_validator_test.py
@@ -126,6 +126,13 @@ class DictValidatorTest:
     # Tests for DictValidator with defined field_validators (with and without default_validator)
 
     @staticmethod
+    def test_empty_dict_validator_valid():
+        """ Test a validator that only returns empty dictionaries (input dictionaries might contain fields, but they will be ignored). """
+        validator = DictValidator(field_validators={})
+        assert validator.validate({}) == {}
+        assert validator.validate({'foo': 42}) == {}
+
+    @staticmethod
     def test_field_dict_without_default_validator_valid():
         """ Validate a dictionary with defined field validators, all fields required, without default_validator. """
         validator = DictValidator(field_validators={


### PR DESCRIPTION
Solves #26.

- `@validataclass` decorator detects fields with validator but without type annotations and will raise errors about that now.
- `@validataclass` allows empty dataclasses now (raised an AttributeError before).