### PR TITLE
ValidataclassMixin: Remove UnsetValues in to_dict()

### DIFF
--- a/src/validataclass/helpers/__init__.py
+++ b/src/validataclass/helpers/__init__.py
@@ -4,8 +4,8 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
+from .unset_value import UnsetValue, UnsetValueType, OptionalUnset, OptionalUnsetNone
 from .dataclass_defaults import Default, DefaultFactory, DefaultUnset, NoDefault
 from .dataclass_mixins import ValidataclassMixin
 from .dataclasses import validataclass, validataclass_field
 from .datetime_range import BaseDateTimeRange, DateTimeRange, DateTimeOffsetRange
-from .unset_value import UnsetValue, UnsetValueType, OptionalUnset, OptionalUnsetNone

--- a/src/validataclass/helpers/dataclass_mixins.py
+++ b/src/validataclass/helpers/dataclass_mixins.py
@@ -9,7 +9,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 import dataclasses
 from typing import Dict
 
-from validataclass.helpers import Default, NoDefault
+from .dataclass_defaults import Default, NoDefault
+from .unset_value import UnsetValue
 
 __all__ = [
     'ValidataclassMixin',
@@ -40,11 +41,22 @@ class ValidataclassMixin:
     ```
     """
 
-    def to_dict(self) -> dict:
+    def to_dict(self, *, keep_unset_values: bool = False) -> dict:
         """
         Returns the data of the object as a dictionary (recursively resolving inner dataclasses as well).
+
+        Filters out all fields with `UnsetValue`, unless the optional parameter `keep_unset_values` is True.
+
+        Parameters:
+            keep_unset_values: If true, fields with value `UnsetValue` are NOT removed from the dictionary (default: False)
         """
-        return dataclasses.asdict(self)  # noqa
+        data = dataclasses.asdict(self)  # noqa
+
+        # Filter out all UnsetValues (unless said otherwise)
+        if not keep_unset_values:
+            data = {key: value for key, value in data.items() if value is not UnsetValue}
+
+        return data
 
     @classmethod
     def create_with_defaults(cls, **kwargs):

--- a/tests/helpers/dataclass_mixins_test.py
+++ b/tests/helpers/dataclass_mixins_test.py
@@ -41,7 +41,7 @@ class ValidataclassMixinTest:
     def test_validataclass_to_dict_validated():
         """ Tests the to_dict() method of the ValidataclassMixin class using a DataclassValidator. """
         validator = DataclassValidator(UnitTestDataclass)
-        obj = validator.validate({'foo': 42, 'bar': 'meep', 'baz': '-1.23'})
+        obj: UnitTestDataclass = validator.validate({'foo': 42, 'bar': 'meep', 'baz': '-1.23'})
         assert obj.to_dict() == {
             'foo': 42,
             'bar': 'meep',
@@ -52,8 +52,18 @@ class ValidataclassMixinTest:
     def test_validataclass_to_dict_validated_with_defaults():
         """ Tests the to_dict() method of the ValidataclassMixin class using a DataclassValidator, with default values. """
         validator = DataclassValidator(UnitTestDataclass)
-        obj = validator.validate({'foo': 42})
-        obj_as_dict = obj.to_dict()
+        obj: UnitTestDataclass = validator.validate({'foo': 42})
+        assert obj.to_dict() == {
+            'foo': 42,
+            'bar': 'bloop',
+        }
+
+    @staticmethod
+    def test_validataclass_to_dict_validated_keep_unset_values():
+        """ Tests the to_dict() method of the ValidataclassMixin class with the parameter keep_unset_value=True. """
+        validator = DataclassValidator(UnitTestDataclass)
+        obj: UnitTestDataclass = validator.validate({'foo': 42})
+        obj_as_dict = obj.to_dict(keep_unset_values=True)
         assert obj_as_dict == {
             'foo': 42,
             'bar': 'bloop',
@@ -69,6 +79,10 @@ class ValidataclassMixinTest:
         obj = UnitTestDataclass.create_with_defaults(foo=42)
         assert isinstance(obj, UnitTestDataclass)
         assert obj.to_dict() == {
+            'foo': 42,
+            'bar': 'bloop',
+        }
+        assert obj.to_dict(keep_unset_values=True) == {
             'foo': 42,
             'bar': 'bloop',
             'baz': UnsetValue,
@@ -101,9 +115,13 @@ class ValidataclassMixinTest:
             foo: int = Default(3)
             bar: Optional[str] = Default(None)
 
-        obj = UnitTestSubclass.create_with_defaults()
+        obj: UnitTestSubclass = UnitTestSubclass.create_with_defaults()
         assert isinstance(obj, UnitTestSubclass)
         assert obj.to_dict() == {
+            'foo': 3,
+            'bar': None,
+        }
+        assert obj.to_dict(keep_unset_values=True) == {
             'foo': 3,
             'bar': None,
             'baz': UnsetValue,


### PR DESCRIPTION
The `to_dict()` method from `ValidataclassMixin` now removes all fields with `UnsetValue` from the dictionary, unless the optional parameter `keep_unset_values` is True.