### PR TITLE
Official support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+[Full changelog](https://github.com/binary-butterfly/validataclass/compare/0.3.2...HEAD)
+
+### Added
+
+- Official support for Python 3.10.
+
+
 ## [0.3.2](https://github.com/binary-butterfly/validataclass/releases/tag/0.3.2) - 2021-11-11
 
 [Full changelog](https://github.com/binary-butterfly/validataclass/compare/0.3.1...0.3.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Official support for Python 3.10.
 
+### Fixed
+
+- Minor fixes for `Optional` type hints.
+
 
 ## [0.3.2](https://github.com/binary-butterfly/validataclass/releases/tag/0.3.2) - 2021-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Minor fixes for `Optional` type hints.
+- Add missing export for `T_Dataclass` in package `validataclass.validators`.
 
 
 ## [0.3.2](https://github.com/binary-butterfly/validataclass/releases/tag/0.3.2) - 2021-11-11

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 # Settings
-DOCKER_MULTI_PYTHON_IMAGE = fkrull/multi-python:focal
+# NOTE: The multi-python image is a fork of fkrull/multi-python, which as of now has not been updated for Python 3.10 yet
+DOCKER_MULTI_PYTHON_IMAGE = gnufede/multi-python:focal
 DOCKER_USER = "$(shell id -u):$(shell id -g)"
 
 .PHONY: all venv build \
 	tox test flake8 open-coverage \
-	docker-tox docker-tox-py37 docker-tox-py38 docker-tox-py39 \
+	docker-tox docker-tox-py37 docker-tox-py38 docker-tox-py39 docker-tox-py310 docker-pull \
 	clean clean-dist clean-all
 
 # Default target
@@ -33,7 +34,7 @@ tox:
 
 # Only run pytest
 test:
-	tox -e 'py{39,38,37,py3}'
+	tox -e 'clean,py{310,39,38,37,py3},report'
 
 # Only run flake8 linter
 flake8:
@@ -50,16 +51,23 @@ docker-tox:
 		--mount "type=bind,src=$(shell pwd),target=/code" \
 		--workdir /code \
 		--env HOME=/tmp/home \
+		--env COVERAGE_FILE=.coverage_docker \
 		$(DOCKER_MULTI_PYTHON_IMAGE) \
 		tox --workdir .tox_docker $(TOX_ARGS)
 
 # Run partial tox test suites in Docker
+docker-tox-py39: TOX_ARGS="-e py310"
+docker-tox-py39: docker-tox
 docker-tox-py39: TOX_ARGS="-e py39"
 docker-tox-py39: docker-tox
 docker-tox-py38: TOX_ARGS="-e py38"
 docker-tox-py38: docker-tox
 docker-tox-py37: TOX_ARGS="-e py37"
 docker-tox-py37: docker-tox
+
+# Pull the latest image of the multi-python Docker image
+docker-pull:
+	docker pull $(DOCKER_MULTI_PYTHON_IMAGE)
 
 
 # Cleanup

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities

--- a/src/validataclass/exceptions/common_exceptions.py
+++ b/src/validataclass/exceptions/common_exceptions.py
@@ -31,9 +31,9 @@ class ValidationError(Exception):
     """
     code: str = 'unknown_error'
     reason: Optional[str] = None
-    extra_data: dict = None
+    extra_data: Optional[dict] = None
 
-    def __init__(self, *, code: str = None, reason: Optional[str] = None, **kwargs):
+    def __init__(self, *, code: Optional[str] = None, reason: Optional[str] = None, **kwargs):
         if code is not None:
             self.code = code
         if reason is not None:
@@ -130,7 +130,7 @@ class InternalValidationError(ValidationError):
     be accessible via `error.internal_error` or `repr(error)` for debugging purposes.
     """
     code = 'internal_error'
-    internal_error: Exception = None
+    internal_error: Optional[Exception] = None
 
     def __init__(self, *, internal_error: Optional[Exception] = None, **kwargs):
         super().__init__(**kwargs)

--- a/src/validataclass/helpers/dataclasses.py
+++ b/src/validataclass/helpers/dataclasses.py
@@ -6,7 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 import dataclasses
 from collections import namedtuple
-from typing import Any, Union, Dict
+from typing import Any, Union, Dict, Optional
 
 from validataclass.exceptions import DataclassValidatorFieldException
 from validataclass.validators import Validator
@@ -196,7 +196,7 @@ def validataclass(cls=None, **kwargs):
     return wrap(cls)
 
 
-def validataclass_field(validator: Validator, default: Any = NoDefault, *, metadata: dict = None, **kwargs):
+def validataclass_field(validator: Validator, default: Any = NoDefault, *, metadata: Optional[dict] = None, **kwargs):
     """
     Define a dataclass field compatible with DataclassValidator.
 

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -31,4 +31,4 @@ from .url_validator import UrlValidator
 # Composite type validators
 from .list_validator import ListValidator
 from .dict_validator import DictValidator
-from .dataclass_validator import DataclassValidator
+from .dataclass_validator import DataclassValidator, T_Dataclass

--- a/tests/helpers/dataclass_mixins_test.py
+++ b/tests/helpers/dataclass_mixins_test.py
@@ -104,7 +104,10 @@ class ValidataclassMixinTest:
         """ Tests the create_with_defaults() class method missing required fields. """
         with pytest.raises(TypeError) as exception_info:
             UnitTestDataclass.create_with_defaults()
-        assert str(exception_info.value) == "__init__() missing 1 required positional argument: 'foo'"
+
+        # The exact exception message changed between Python versions 3.9 (first variant) and 3.10 (second variant)
+        assert str(exception_info.value) == "__init__() missing 1 required positional argument: 'foo'" \
+            or str(exception_info.value) == "UnitTestDataclass.__init__() missing 1 required positional argument: 'foo'"
 
     @staticmethod
     def test_create_with_defaults_on_subclass():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py{39,38,37,py3},flake8,report
+envlist = clean,py{310,39,38,37,py3},flake8,report
 skip_missing_interpreters = true
 isolated_build = true
 


### PR DESCRIPTION
This PR adds "official support" for Python 3.10, i.e. it adds a test environment for Python 3.10 and fixes a small issue in the unit tests.

(Also smuggled in some unrelated minor fixes.)