### PR TITLE
IntegerValidator: Implement allow_strings parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Official support for Python 3.10.
+- `IntegerValidator`: Add optional boolean parameter `allow_strings` to accept integers as strings (e.g. `"123"`).
 
 ### Fixed
 

--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -249,9 +249,14 @@ point arithmetics work, while integers and decimals are always precise.
 
 ### IntegerValidator
 
-The `IntegerValidator` accepts integer values (as type `int`, not as strings) and returns those values unmodified.
+The `IntegerValidator` accepts and returns integer values. By default, only actual integers (i.e. no strings) are
+accepted, so for example the string `"123"` would result in an `InvalidTypeError`.
 
-Optionally you can specify a range of valid values using `min_value` and `max_value`.
+The optional parameter `allow_strings` can be set to `True` to allow both integers and numeric strings as input. The
+validator will convert strings to integers in that case, so the input values `123` (integer) and `"123"` (string) will
+both result in the integer output value `123`.
+
+Optionally you can also specify a range of valid values using `min_value` and `max_value`.
 
 **Examples:**
 
@@ -264,6 +269,13 @@ validator.validate(0)     # will return 0
 validator.validate(123)   # will return 123
 validator.validate(-123)  # will return -123
 validator.validate("1")   # will raise InvalidTypeError (use DecimalValidator instead)
+
+# allow_strings parameter: Accept integers also as strings
+validator = IntegerValidator(allow_strings=True)
+validator.validate(42)      # will return 42
+validator.validate("42")    # will return 42
+validator.validate("-123")  # will return -123
+validator.validate("foo")   # will raise InvalidIntegerError
 
 # min_value parameter: Only allow zero or positive numbers
 validator = IntegerValidator(min_value=0)

--- a/src/validataclass/exceptions/__init__.py
+++ b/src/validataclass/exceptions/__init__.py
@@ -17,7 +17,7 @@ from .dict_exceptions import DictFieldsValidationError, DictInvalidKeyTypeError,
 from .email_exceptions import InvalidEmailError
 from .list_exceptions import ListItemsValidationError, ListLengthError
 from .misc_exceptions import ValueNotAllowedError
-from .number_exceptions import NumberRangeError, DecimalPlacesError, InvalidDecimalError, NonFiniteNumberError
+from .number_exceptions import NumberRangeError, DecimalPlacesError, InvalidIntegerError, InvalidDecimalError, NonFiniteNumberError
 from .regex_exceptions import RegexMatchError
 from .string_exceptions import StringInvalidLengthError, StringTooShortError, StringTooLongError, StringInvalidCharactersError
 from .url_exceptions import InvalidUrlError

--- a/src/validataclass/exceptions/number_exceptions.py
+++ b/src/validataclass/exceptions/number_exceptions.py
@@ -11,6 +11,7 @@ from validataclass.exceptions import ValidationError
 __all__ = [
     'NumberRangeError',
     'DecimalPlacesError',
+    'InvalidIntegerError',
     'InvalidDecimalError',
     'NonFiniteNumberError',
 ]
@@ -18,11 +19,11 @@ __all__ = [
 
 class NumberRangeError(ValidationError):
     """
-    Validation error raised by number validators (e.g. `IntegerValidator`, `DecimalValidator`, ...) when a number range requirement
-    (minimal and/or maximal value) is specified and the input does not match those requirements.
+    Validation error raised by number validators (e.g. `IntegerValidator`, `DecimalValidator`, ...) when a number range
+    requirement (minimal and/or maximal value) is specified and the input does not match those requirements.
 
-    May contain the extra fields 'min_value' and 'max_value', depending on which are specified. The type of these fields depends on
-    the validator, e.g. an IntegerValidator sets integers, while a DecimalValidator sets decimal strings.
+    May contain the extra fields 'min_value' and 'max_value', depending on which are specified. The type of these fields
+    depends on the validator, e.g. an IntegerValidator sets integers, while a DecimalValidator sets decimal strings.
     """
     code = 'number_range_error'
 
@@ -34,8 +35,8 @@ class NumberRangeError(ValidationError):
 
 class DecimalPlacesError(ValidationError):
     """
-    Validation error raised by `DecimalValidator` when a minimum or maximum number of decimal places is specified and the input number
-    has too many or too little decimal places.
+    Validation error raised by `DecimalValidator` when a minimum or maximum number of decimal places is specified and
+    the input number has too many or too little decimal places.
 
     May contain the extra fields 'min_places' and 'max_places' (integers), depending on which are specified.
     """
@@ -47,16 +48,25 @@ class DecimalPlacesError(ValidationError):
         super().__init__(**min_places_args, **max_places_args, **kwargs)
 
 
+class InvalidIntegerError(ValidationError):
+    """
+    Validation error raised by `IntegerValidator` with `allow_strings=True` when an input string cannot be parsed as an
+    integer value, i.e. the string contains invalid characters or is empty.
+    """
+    code = 'invalid_integer'
+
+
 class InvalidDecimalError(ValidationError):
     """
-    Validation error raised by `DecimalValidator` when an input string cannot be parsed as a decimal value, i.e. the string is malformed.
+    Validation error raised by `DecimalValidator` when an input string cannot be parsed as a decimal value, i.e. the
+    string is malformed.
     """
     code = 'invalid_decimal'
 
 
 class NonFiniteNumberError(ValidationError):
     """
-    Validation error raised by `FloatValidator` (and subclasses) when an input string can be parsed as a float, but does not have a
-    finite value (i.e. it is either (+/-)Infinity or NaN).
+    Validation error raised by `FloatValidator` (and subclasses) when an input string can be parsed as a float, but does
+    not have a finite value (i.e. it is either (+/-)Infinity or NaN).
     """
     code = 'not_a_finite_number'

--- a/src/validataclass/validators/integer_validator.py
+++ b/src/validataclass/validators/integer_validator.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from typing import Any, Optional
 
 from .validator import Validator
-from validataclass.exceptions import InvalidValidatorOptionException, NumberRangeError
+from validataclass.exceptions import InvalidValidatorOptionException, InvalidIntegerError, NumberRangeError
 
 __all__ = [
     'IntegerValidator',
@@ -18,19 +18,30 @@ class IntegerValidator(Validator):
     """
     Validator for integer values, optionally with value range requirements.
 
+    By default, only actual integer values (no strings) are allowed. Use the parameter `allow_strings=True` to allow
+    numeric strings, e.g. the strings "-123" and "123" would be accepted and automatically converted to integers.
+
     Examples:
 
     ```
+    # Accepts any integer (e.g. -123456, 0, 123456, but not a string like "123")
     IntegerValidator()
-    IntegerValidator(min_value=0)  # Only allow zero or positive numbers
-    IntegerValidator(min_value=1, max_value=10)  # Only allow values 1 to 10 (including 1 and 10)
+
+    # Accepts numeric strings, which will be converted to integers (e.g. "1234" -> 1234; "-123" -> -123)
+    IntegerValidator(allow_strings=True)
+
+    # Only accepts zero or positive numbers
+    IntegerValidator(min_value=0)
+
+    # Only accepts values 1 to 10 (including the numbers 1 and 10)
+    IntegerValidator(min_value=1, max_value=10)
     ```
 
     Note: While it is allowed to set `max_value` without setting `min_value`, this might not do what you expect. For example,
     an `IntegerValidator(max_value=10)` allows all values less than or equal to 10. This includes ANY negative number though,
     so for example `-1234567` would be valid input!
 
-    Valid input: `int`
+    Valid input: `int` (and `str` if `allow_strings=True`)
     Output: `int`
     """
 
@@ -38,13 +49,17 @@ class IntegerValidator(Validator):
     min_value: Optional[int] = None
     max_value: Optional[int] = None
 
-    def __init__(self, *, min_value: Optional[int] = None, max_value: Optional[int] = None):
+    # Whether to allow integers as strings
+    allow_strings: bool = False
+
+    def __init__(self, *, min_value: Optional[int] = None, max_value: Optional[int] = None, allow_strings: bool = False):
         """
         Create a IntegerValidator with optional value range.
 
         Parameters:
             min_value: Integer, specifies lowest value an input integer may have (default: None, no minimum value)
             max_value: Integer, specifies highest value an input integer may have (default: None, no maximum value)
+            allow_strings: Boolean, if True, numeric strings (e.g. "123") are accepted and converted to integers (default: False)
         """
         # Check parameter validity
         if min_value is not None and max_value is not None and min_value > max_value:
@@ -52,12 +67,20 @@ class IntegerValidator(Validator):
 
         self.min_value = min_value
         self.max_value = max_value
+        self.allow_strings = allow_strings
 
     def validate(self, input_data: Any) -> int:
         """
         Validate type (and optionally value) of input data. Returns unmodified integer.
         """
-        self._ensure_type(input_data, int)
+        self._ensure_type(input_data, [int, str] if self.allow_strings else int)
+
+        # If allow_strings is True, convert strings to integers
+        if type(input_data) is str:
+            try:
+                input_data = int(input_data)
+            except ValueError:
+                raise InvalidIntegerError()
 
         # Check if value is in allowed range
         if (self.min_value is not None and input_data < self.min_value) or (self.max_value is not None and input_data > self.max_value):


### PR DESCRIPTION
This PR adds a new optional parameter `allow_strings` to the IntegerValidator to accept integers as strings (e.g. `"123"` -> `123`).

Closes #17.