### PR TITLE
Reimplement FloatToDecimalValidator and add NumericValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FloatValidator`: Add optional boolean parameter `allow_integers`.
 - `FloatToDecimalValidator`: Add optional boolean parameters `allow_integers` and `allow_strings`. Also, minimum and
   maximum values can now be specified as floats, integers, `Decimal` or decimal strings. 
+- `NumericValidator`: New validator as shortcut for `FloatToDecimalValidator` with `allow_integers` and `allow_strings`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FloatToDecimalValidator`: Add optional boolean parameters `allow_integers` and `allow_strings`. Also, minimum and
   maximum values can now be specified as floats, integers, `Decimal` or decimal strings. 
 
+### Changed
+
+- `FloatToDecimalValidator`: Reimplemented validator, based on `DecimalValidator` instead of `FloatValidator`.
+  - `NumberRangeError` exceptions raised by this validator now consistently use decimal strings for min/max values.
+
 ### Fixed
 
 - Minor fixes for `Optional` type hints.

--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -33,8 +33,9 @@ A much more useful distinction is to categorize the validators according to thei
 - Numeric types:
   - `IntegerValidator`: Validates integers (as `int`, not as `str`)
   - `FloatValidator`: Validates floats (as `float`, not as `str`)
-  - `DecimalValidator`: Validates decimal **strings** (e.g. `"1.23"`) to `decimal.decimal` **objects**
-  - `FloatToDecimalValidator`: Validates **floats** (e.g. `1.23`) to `decimal.decimal` **objects**
+  - `DecimalValidator`: Validates decimal **strings** (e.g. `"1.23"`) to `decimal.decimal` objects
+  - `FloatToDecimalValidator`: Validates floats (e.g. `1.23`) to `decimal.decimal` objects
+  - `NumericValidator`: Validates integers, floats **and** decimal strings to `decimal.Decimal` objects
 
 - Date and time types:
   - `DateValidator`: Validates date **strings** (e.g. `"2021-12-31"`) to `datetime.date` **objects**
@@ -243,8 +244,8 @@ validator.validate("https://example.com")  # will raise InvalidUrlError(reason='
 
 The following validators parse different types of numbers, namely **integers**, **floats** and **decimals**.
 
-In most cases it is recommended to use either `IntegerValidator` or `DecimalValidator`. Floats are error-prone due to how binary floating
-point arithmetics work, while integers and decimals are always precise.
+In most cases it is recommended to use either `IntegerValidator` or `DecimalValidator`. Floats are error-prone due to
+how binary floating point arithmetics work, while integers and decimals are always precise.
 
 
 ### IntegerValidator
@@ -405,6 +406,10 @@ By default, this validator only accepts floats as input. Optionally it can also 
 `Decimal('42.0')`. You can also set the parameter `allow_strings=True` to allow decimal strings, which will be parsed
 by the underlying `DecimalValidator` (e.g. `"1.23"` will result in a `Decimal('1.23')`).
 
+If you want to accept all three numeric input types (integers, floats and decimal strings), you can simply combine
+`allow_integers=True` and `allow_strings=True`. As a shortcut for this, you can also use the `NumericValidator`, which
+basically is just a `FloatToDecimalValidator` with those two options always enabled.
+
 Like the `DecimalValidator` it supports the optional parameters `min_value` and `max_value` (specified as `Decimal`,
 decimal strings, floats or integers), as well as `output_places`. However, it **does not** support the `min_places` and
 max_places` parameters (those are technically not possible with floats)!
@@ -442,6 +447,40 @@ validator.validate(0.0)     # will return Decimal('0.000')
 validator.validate(0.1234)  # will return Decimal('0.123')
 validator.validate(0.1235)  # will return Decimal('0.124')
 validator.validate(1.0)     # will return Decimal('1.000')
+```
+
+
+### NumericValidator
+
+The `NumericValidator` accepts numeric values as integers, floats **and** decimal strings and converts all of them to
+`decimal.Decimal` objects.
+
+This validator is a special version of the `FloatToDecimalValidator` with the options `allow_integers` and `allow_strings`
+always enabled, and is intended as a shortcut.
+
+Like the `FloatToDecimalValidator`, the `NumericValidator` supports the optional parameters `min_value` and `max_value`
+to specify the allowed value range, as well as `output_places` to set a fixed number of decimal places in the output
+value.
+
+**Examples:**
+
+```python
+from validataclass.validators import NumericValidator
+
+# Accept any numeric value (integers, floats and decimal strings)
+# This validator is equivalent to: FloatToDecimalValidator(allow_integers=True, allow_strings=True) 
+validator = NumericValidator()
+validator.validate(123)      # will return Decimal('123')
+validator.validate(1.234)    # will return Decimal('1.234')
+validator.validate("1.234")  # will return Decimal('1.234')
+
+# Number range and output places: Allow values from 0 to 00, always output with 2 decimal places
+validator = NumericValidator(min_value=0, max_value=10, output_places=2)
+validator.validate(0)        # will return Decimal('0.00')
+validator.validate(0.0)      # will return Decimal('0.00')
+validator.validate("0.000")  # will return Decimal('0.00')
+validator.validate("1.234")  # will return Decimal('1.23')
+validator.validate("1.235")  # will return Decimal('1.24')
 ```
 
 

--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -398,18 +398,16 @@ validator.validate("100000.00")  # will return Decimal('100000.000')
 ### FloatToDecimalValidator
 
 The `FloatToDecimalValidator` accepts **float** values (like the `FloatValidator`) and **converts** them to `Decimal`
-objects (like the `DecimalValidator`).
+objects (like the `DecimalValidator`). Internally it is based on the `DecimalValidator`.
 
-Like the `FloatValidator`, this validator only accepts floats by default, but can also accept integers by setting the
-parameter `allow_integers=True`. For example, the integer `42` will result in a `Decimal('42')`, while the float `42.0`
-results in a `Decimal('42.0')`.
+By default, this validator only accepts floats as input. Optionally it can also accept integers by setting the parameter
+`allow_integers=True`, e.g. the integer `42` will then result in a `Decimal('42')`, while the float `42.0` results in a
+`Decimal('42.0')`. You can also set the parameter `allow_strings=True` to allow decimal strings, which will be parsed
+by the underlying `DecimalValidator` (e.g. `"1.23"` will result in a `Decimal('1.23')`).
 
-Additionally, by setting the parameter `allow_strings=True` the validator will accept decimal strings, which will then
-be parsed internally using a `DecimalValidator` (e.g. `"1.23"` will result in a `Decimal('1.23')`).
-
-Like the `DecimalValidator` it supports the optional parameters `min_value`, `max_value` (which can both be specified
-using floats, integers, `Decimal` or decimal strings) and `output_places`. However, it **does not** support the
-`min_places` and `max_places` parameters (those are technically not possible with floats)!
+Like the `DecimalValidator` it supports the optional parameters `min_value` and `max_value` (specified as `Decimal`,
+decimal strings, floats or integers), as well as `output_places`. However, it **does not** support the `min_places` and
+max_places` parameters (those are technically not possible with floats)!
 
 **Note:** Due to the way that floats work, the resulting decimals can have inaccuracies! It is recommended to use
 `DecimalValidator` with decimal strings instead of floats as input whenever possible. This validator mainly exists for

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -21,6 +21,7 @@ from .any_of_validator import AnyOfValidator
 from .enum_validator import EnumValidator
 from .decimal_validator import DecimalValidator
 from .float_to_decimal_validator import FloatToDecimalValidator
+from .numeric_validator import NumericValidator
 from .regex_validator import RegexValidator
 from .date_validator import DateValidator
 from .time_validator import TimeValidator, TimeFormat

--- a/src/validataclass/validators/numeric_validator.py
+++ b/src/validataclass/validators/numeric_validator.py
@@ -1,0 +1,82 @@
+"""
+validataclass
+Copyright (c) 2021, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from decimal import Decimal
+from typing import Optional, Union
+
+from .float_to_decimal_validator import FloatToDecimalValidator
+
+__all__ = [
+    'NumericValidator',
+]
+
+
+class NumericValidator(FloatToDecimalValidator):
+    """
+    Validator that accepts numeric values in different types (integers, floats and decimal strings) and converts them
+    to `decimal.Decimal` objects.
+
+    This validator is based on the `FloatToDecimalValidator`. In fact, the validator is basically just a shortcut for
+    `FloatToDecimalValidator(allow_integers=True, allow_strings=True)`.
+
+    The validator supports the optional parameters 'min_value', 'max_value' and 'output_places' which will be passed
+    to the `FloatToDecimalValidator`.
+
+    NOTE: Due to the way that floats work, the resulting decimals for float input values can have inaccuracies! It is
+    recommended to use `DecimalValidator` with decimal strings as input data instead of using float input (e.g. strings
+    like `"1.234"` instead of floats like `1.234`). This validator mainly exists for cases where you need to accept
+    floats as input (e.g. with APIs that you have no control over).
+
+    Examples:
+
+    ```
+    # Allows any numeric value (integer, float or string) and returns them as Decimals:
+    # int: 123 -> Decimal('123')
+    # float: -1.23 -> Decimal('-1.23')  (beware of potential float inaccuracies though)
+    # str: "0.123" -> Decimal('0.123')
+    NumericValidator()
+
+    # Only allow zero or positive numbers (e.g. 0, 1000, 0.01, "0.123")
+    NumericValidator(min_value=0)
+
+    # Only allow values from -0.5 to 0.5
+    NumericValidator(min_value='-0.5', max_value='0.5')
+
+    # No input restrictions, but output Decimals always have a fixed number of decimal places:
+    # 1234 -> Decimal('1234.00')
+    # -0.1 -> Decimal('-0.10')
+    # "0.6666" -> Decimal('0.67') (exact value depends on decimal context)
+    NumericValidator(output_places=2)
+    ```
+
+    Valid input: `int`, `float`, `str` (decimal strings)
+    Output: `decimal.Decimal`
+    """
+
+    def __init__(
+        self, *,
+        min_value: Optional[Union[Decimal, str, float, int]] = None,
+        max_value: Optional[Union[Decimal, str, float, int]] = None,
+        output_places: Optional[int] = None,
+    ):
+        """
+        Create a `NumericValidator` with optional value range and optional number of decimal places in output value.
+
+        The parameters 'min_value', 'max_value' and 'output_places' are passed to the underlying `FloatToDecimalValidator`.
+
+        Parameters:
+            min_value: Decimal, str, float or int, specifies lowest value an input float may have (default: None, no minimum value)
+            max_value: Decimal, str, float or int, specifies highest value an input float may have (default: None, no maximum value)
+            output_places: Integer, number of decimal places the output Decimal object shall have (default: None, output equals input)
+        """
+        # Initialize base FloatToDecimalValidator with allow_integers and allow_strings always being enabled
+        super().__init__(
+            min_value=min_value,
+            max_value=max_value,
+            output_places=output_places,
+            allow_integers=True,
+            allow_strings=True,
+        )

--- a/tests/validators/float_to_decimal_validator_test.py
+++ b/tests/validators/float_to_decimal_validator_test.py
@@ -5,8 +5,10 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
+
 import pytest
 
+from tests.test_utils import unpack_params
 from validataclass.exceptions import RequiredValueError, InvalidTypeError, NumberRangeError, NonFiniteNumberError, \
     InvalidDecimalError, InvalidValidatorOptionException
 from validataclass.validators import FloatToDecimalValidator
@@ -15,19 +17,19 @@ from validataclass.validators import FloatToDecimalValidator
 class FloatToDecimalValidatorTest:
     @staticmethod
     @pytest.mark.parametrize(
-        'input_data, expected_decimal_string', [
-            (0.0, '0'),
+        'input_data, expected_decimal_str', [
+            (0.0, '0.0'),
             (1.234, '1.234'),
             (-0.001, '-0.001'),
             (-123456.789, '-123456.789'),
         ]
     )
-    def test_valid_float(input_data, expected_decimal_string):
+    def test_valid_float(input_data, expected_decimal_str):
         """ Test FloatToDecimalValidator with valid floats. """
         validator = FloatToDecimalValidator()
         decimal = validator.validate(input_data)
         assert type(decimal) is Decimal
-        assert decimal == Decimal(expected_decimal_string)
+        assert str(decimal) == expected_decimal_str
 
     @staticmethod
     def test_invalid_none():
@@ -62,53 +64,87 @@ class FloatToDecimalValidatorTest:
 
     @staticmethod
     @pytest.mark.parametrize(
-        'min_value, max_value, input_data, expected_decimal_string', [
+        'min_value, max_value, input_data, expected_decimal_str', [
             # min_value only (as float)
-            (3.0, None, 3.0, '3.0'),
-            (3.0, None, 3.1, '3.1'),
+            *unpack_params(
+                3.0, None,
+                [
+                    (3.0, '3.0'),
+                    (3.001, '3.001'),
+                    (9.999, '9.999'),
+                ],
+            ),
+
             # max_value only (as float)
-            (None, 10.0, -999.0, '-999.0'),
-            (None, 10.0, 9.9, '9.9'),
-            (None, 10.0, 10.0, '10.0'),
+            *unpack_params(
+                None, 10.0,
+                [
+                    (-999.0, '-999.0'),
+                    (9.9, '9.9'),
+                    (10.0, '10.0'),
+                ],
+            ),
+
             # min_value and max_value (as int)
-            (0, 1, 0.0, '0.0'),
-            (0, 1, 0.9, '0.9'),
-            (0, 1, 1.0, '1.0'),
-            # min_value and max_value (as Decimal)
-            (Decimal('-1.0'), Decimal('1.0'), -1.0, '-1.0'),
-            (Decimal('-1.0'), Decimal('1.0'), 0.9, '0.9'),
-            (Decimal('-1.0'), Decimal('1.0'), 1.0, '1.0'),
-            # min_value and max_value (as str)
-            ('-1.0', '1.0', -1.0, '-1.0'),
-            ('-1.0', '1.0', 0.9, '0.9'),
-            ('-1.0', '1.0', 1.0, '1.0'),
+            *unpack_params(
+                0, 1,
+                [
+                    (0.0, '0.0'),
+                    (0.001, '0.001'),
+                    (0.999, '0.999'),
+                    (1.0, '1.0'),
+                ],
+            ),
+
+            # min_value and max_value (as Decimal and str)
+            *unpack_params(
+                Decimal('-1.0'), '1.0',
+                [
+                    (-1.0, '-1.0'),
+                    (-0.999, '-0.999'),
+                    (0.999, '0.999'),
+                    (1.0, '1.0'),
+                ],
+            ),
         ]
     )
-    def test_float_value_range_valid(min_value, max_value, input_data, expected_decimal_string):
-        """ Test FloatToDecimalValidator with range requirements with a list of valid floats. """
+    def test_float_value_range_valid(min_value, max_value, input_data, expected_decimal_str):
+        """ Test FloatToDecimalValidator with range requirements with valid floats. """
         validator = FloatToDecimalValidator(min_value=min_value, max_value=max_value)
         output_value = validator.validate(input_data)
-
         assert type(output_value) is Decimal
-        assert output_value == Decimal(expected_decimal_string)
+        assert str(output_value) == expected_decimal_str
 
     @staticmethod
     @pytest.mark.parametrize(
-        'min_value, max_value, input_data_list', [
+        'min_value, max_value, input_data', [
             # min_value only (as float)
-            (3.0, None, [2.999, 2.9, -3.0]),
+            *unpack_params(
+                3.0, None,
+                [2.999, 2.9, -3.0],
+            ),
+
             # max_value only (as float)
-            (None, 10.0, [10.001, 11.0, 999.0]),
+            *unpack_params(
+                None, 10.0,
+                [10.001, 11.0, 999.0],
+            ),
+
             # min_value and max_value (as int)
-            (0, 1, [-1.0, -0.001, 1.001, 1.1]),
-            # min_value and max_value (as Decimal)
-            (Decimal('-1.0'), Decimal('1.0'), [-1.1, 1.1]),
-            # min_value and max_value (as str)
-            ('-1.0', '1.0', [-1.1, 1.1]),
+            *unpack_params(
+                0, 1,
+                [-1.0, -0.001, 1.001, 1.1],
+            ),
+
+            # min_value and max_value (as Decimal and str)
+            *unpack_params(
+                Decimal('-1.0'), '1.0',
+                [-1.1, -1.001, 1.001, 1.1],
+            ),
         ]
     )
-    def test_float_value_range_invalid(min_value, max_value, input_data_list):
-        """ Test FloatToDecimalValidator with range requirements with a list of invalid floats. """
+    def test_float_value_range_invalid(min_value, max_value, input_data):
+        """ Test FloatToDecimalValidator with range requirements with invalid floats. """
         validator = FloatToDecimalValidator(min_value=min_value, max_value=max_value)
 
         # Construct error dict with min_value and/or max_value, depending on which is specified
@@ -116,16 +152,15 @@ class FloatToDecimalValidatorTest:
         expected_error_dict.update({'max_value': str(max_value)} if max_value is not None else {})
         expected_error_dict.update({'min_value': str(min_value)} if min_value is not None else {})
 
-        for input_data in input_data_list:
-            with pytest.raises(NumberRangeError) as exception_info:
-                validator.validate(input_data)
-            assert exception_info.value.to_dict() == expected_error_dict
+        with pytest.raises(NumberRangeError) as exception_info:
+            validator.validate(input_data)
+        assert exception_info.value.to_dict() == expected_error_dict
 
     # Test optional allow_integers parameter
 
     @staticmethod
     @pytest.mark.parametrize(
-        'input_data, expected_decimal_string', [
+        'input_data, expected_decimal_str', [
             # Floats should still work of course
             (1.234, '1.234'),
             (-123.4, '-123.4'),
@@ -135,12 +170,12 @@ class FloatToDecimalValidatorTest:
             (-123, '-123'),
         ]
     )
-    def test_allow_integers_valid(input_data, expected_decimal_string):
+    def test_allow_integers_valid(input_data, expected_decimal_str):
         """ Test FloatToDecimalValidator with allow_integers=True with valid input (both as floats and integers). """
         validator = FloatToDecimalValidator(allow_integers=True)
         decimal = validator.validate(input_data)
         assert type(decimal) is Decimal
-        assert decimal == Decimal(expected_decimal_string)
+        assert str(decimal) == expected_decimal_str
 
     @staticmethod
     def test_allow_integers_with_invalid_type():
@@ -159,10 +194,10 @@ class FloatToDecimalValidatorTest:
         validator = FloatToDecimalValidator(min_value=-1.9, max_value=10.0, allow_integers=True)
 
         # Valid input
-        assert validator.validate(-1) == Decimal('-1')
-        assert validator.validate(10) == Decimal('10')
-        assert validator.validate(-1.9) == Decimal('-1.9')
-        assert validator.validate(10.0) == Decimal('10.0')
+        assert str(validator.validate(-1)) == '-1'
+        assert str(validator.validate(10)) == '10'
+        assert str(validator.validate(-1.9)) == '-1.9'
+        assert str(validator.validate(10.0)) == '10.0'
 
         # Invalid input
         for input_value in [-2, 11, -1.91, 10.1]:
@@ -178,7 +213,7 @@ class FloatToDecimalValidatorTest:
 
     @staticmethod
     @pytest.mark.parametrize(
-        'input_data, expected_decimal_string', [
+        'input_data, expected_decimal_str', [
             # Floats should still work of course
             (1.234, '1.234'),
             (-123.4, '-123.4'),
@@ -189,12 +224,12 @@ class FloatToDecimalValidatorTest:
             ('-1.23', '-1.23'),
         ]
     )
-    def test_allow_strings_valid(input_data, expected_decimal_string):
+    def test_allow_strings_valid(input_data, expected_decimal_str):
         """ Test FloatToDecimalValidator with allow_strings=True with valid input (both as floats and strings). """
         validator = FloatToDecimalValidator(allow_strings=True)
         decimal = validator.validate(input_data)
         assert type(decimal) is Decimal
-        assert decimal == Decimal(expected_decimal_string)
+        assert str(decimal) == expected_decimal_str
 
     @staticmethod
     @pytest.mark.parametrize('input_data', ['', 'banana', '1234x', '$123', '1,234', 'Infinity', 'NaN', '.', '1e3'])
@@ -224,8 +259,8 @@ class FloatToDecimalValidatorTest:
         validator = FloatToDecimalValidator(min_value='-1.9', max_value='10.0', allow_strings=True)
 
         # Valid input
-        assert validator.validate('-1.9') == Decimal('-1.9')
-        assert validator.validate('10.0') == Decimal('10.0')
+        assert str(validator.validate('-1.9')) == '-1.9'
+        assert str(validator.validate('10.0')) == '10.0'
 
         # Invalid input
         for input_value in ['-1.91', '10.1']:
@@ -241,7 +276,7 @@ class FloatToDecimalValidatorTest:
 
     @staticmethod
     @pytest.mark.parametrize(
-        'input_data, expected_decimal_string', [
+        'input_data, expected_decimal_str', [
             # Floats
             (0.0, '0.0'),
             (1.234, '1.234'),
@@ -256,12 +291,12 @@ class FloatToDecimalValidatorTest:
             ('-123.0', '-123.0'),
         ]
     )
-    def test_allow_integers_and_strings_valid(input_data, expected_decimal_string):
+    def test_allow_integers_and_strings_valid(input_data, expected_decimal_str):
         """ Test FloatToDecimalValidator with allow_integers=True AND allow_strings=True with valid input. """
         validator = FloatToDecimalValidator(allow_integers=True, allow_strings=True)
         decimal = validator.validate(input_data)
         assert type(decimal) is Decimal
-        assert decimal == Decimal(expected_decimal_string)
+        assert str(decimal) == expected_decimal_str
 
     @staticmethod
     def test_allow_integers_and_strings_with_invalid_strings():
@@ -288,7 +323,7 @@ class FloatToDecimalValidatorTest:
 
     @staticmethod
     @pytest.mark.parametrize(
-        'output_places, input_data, expected_output', [
+        'output_places, input_data, expected_decimal_str', [
             # output_places=0
             (0, 0.0, '0'),
             (0, -42.0, '-42'),
@@ -303,10 +338,12 @@ class FloatToDecimalValidatorTest:
             (3, 123.456789, '123.457'),
         ]
     )
-    def test_output_places(output_places, input_data, expected_output):
+    def test_output_places(output_places, input_data, expected_decimal_str):
         """ Test FloatToDecimalValidator with output_places parameter (fixed number of decimal places in output value). """
         validator = FloatToDecimalValidator(output_places=output_places)
-        assert validator.validate(input_data) == Decimal(expected_output)
+        decimal = validator.validate(input_data)
+        assert type(decimal) is Decimal
+        assert str(decimal) == expected_decimal_str
 
     # Invalid validator parameters
 

--- a/tests/validators/float_to_decimal_validator_test.py
+++ b/tests/validators/float_to_decimal_validator_test.py
@@ -113,8 +113,8 @@ class FloatToDecimalValidatorTest:
 
         # Construct error dict with min_value and/or max_value, depending on which is specified
         expected_error_dict = {'code': 'number_range_error'}
-        expected_error_dict.update({'max_value': float(max_value)} if max_value is not None else {})
-        expected_error_dict.update({'min_value': float(min_value)} if min_value is not None else {})
+        expected_error_dict.update({'max_value': str(max_value)} if max_value is not None else {})
+        expected_error_dict.update({'min_value': str(min_value)} if min_value is not None else {})
 
         for input_data in input_data_list:
             with pytest.raises(NumberRangeError) as exception_info:
@@ -170,8 +170,8 @@ class FloatToDecimalValidatorTest:
                 validator.validate(input_value)
             assert exception_info.value.to_dict() == {
                 'code': 'number_range_error',
-                'min_value': -1.9,
-                'max_value': 10.0,
+                'min_value': '-1.9',
+                'max_value': '10.0',
             }
 
     # Test optional allow_strings parameter

--- a/tests/validators/numeric_validator_test.py
+++ b/tests/validators/numeric_validator_test.py
@@ -5,6 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
+
 import pytest
 
 from tests.test_utils import unpack_params

--- a/tests/validators/numeric_validator_test.py
+++ b/tests/validators/numeric_validator_test.py
@@ -1,0 +1,261 @@
+"""
+validataclass
+Copyright (c) 2021, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from decimal import Decimal
+import pytest
+
+from tests.test_utils import unpack_params
+from validataclass.exceptions import RequiredValueError, InvalidTypeError, InvalidDecimalError, NumberRangeError, \
+    NonFiniteNumberError, InvalidValidatorOptionException
+from validataclass.validators import NumericValidator
+
+
+class NumericValidatorTest:
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data, expected_decimal_str', [
+            # Integers (shouldn't have trailing '.0' in the output)
+            (0, '0'),
+            (42, '42'),
+            (-123, '-123'),
+
+            # Floats
+            (0.0, '0.0'),
+            (0.001, '0.001'),
+            (1.234, '1.234'),
+            (-123.4, '-123.4'),
+            (-123456.789, '-123456.789'),
+
+            # Decimal strings
+            ('0', '0'),
+            ('0.0', '0.0'),
+            ('123', '123'),
+            ('123.0', '123.0'),
+            ('-1.23456', '-1.23456'),
+            ('+.001', '0.001'),
+        ]
+    )
+    def test_valid_input(input_data, expected_decimal_str):
+        """ Test NumericValidator with valid input data. """
+        validator = NumericValidator()
+        decimal = validator.validate(input_data)
+        assert type(decimal) is Decimal
+        assert str(decimal) == expected_decimal_str
+
+    @staticmethod
+    def test_invalid_none():
+        """ Check that NumericValidator raises exception for None as value. """
+        validator = NumericValidator()
+        with pytest.raises(RequiredValueError) as exception_info:
+            validator.validate(None)
+        assert exception_info.value.to_dict() == {'code': 'required_value'}
+
+    @staticmethod
+    @pytest.mark.parametrize('input_data', [True, False, [1.234]])
+    def test_invalid_wrong_type(input_data):
+        """ Check that NumericValidator raises exceptions for values that are neither of the types float, int and str. """
+        validator = NumericValidator()
+        with pytest.raises(InvalidTypeError) as exception_info:
+            validator.validate(input_data)
+        assert exception_info.value.to_dict() == {
+            'code': 'invalid_type',
+            'expected_types': ['float', 'int', 'str'],
+        }
+
+    @staticmethod
+    @pytest.mark.parametrize('input_data', ['', 'banana', '1234x', '$123', '1,234', 'Infinity', 'NaN', '.', '1e3'])
+    def test_invalid_decimal_strings(input_data):
+        """ Test that NumericValidator raises exceptions for invalid or malformed strings. """
+        validator = NumericValidator()
+        with pytest.raises(InvalidDecimalError) as exception_info:
+            validator.validate(input_data)
+        assert exception_info.value.to_dict() == {
+            'code': 'invalid_decimal',
+        }
+
+    @staticmethod
+    @pytest.mark.parametrize('input_data', [float('infinity'), float('-infinity'), float('nan')])
+    def test_invalid_non_finite_numbers(input_data):
+        """ Test NumericValidator with non-finite values (infinity, NaN). """
+        validator = NumericValidator()
+        with pytest.raises(NonFiniteNumberError) as exception_info:
+            validator.validate(input_data)
+        assert exception_info.value.to_dict() == {'code': 'not_a_finite_number'}
+
+    # Test value range requirements
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'min_value, max_value, input_data, expected_decimal_str', [
+            # min_value only (as integer)
+            *unpack_params(
+                1, None,
+                [
+                    (1, '1'),
+                    (1.0, '1.0'),
+                    ('1.000', '1.000'),
+                    (999999, '999999'),
+                    (999999.999, '999999.999'),
+                    ('999999', '999999'),
+                ],
+            ),
+
+            # max_value only (as float)
+            *unpack_params(
+                None, 10.0,
+                [
+                    (-9999, '-9999'),
+                    (-9999.0, '-9999.0'),
+                    ('-9999.999', '-9999.999'),
+                    (10, '10'),
+                    (10.0, '10.0'),
+                    ('10.0', '10.0'),
+                ],
+            ),
+
+            # min_value and max_value (as strings)
+            *unpack_params(
+                '0', '1',
+                [
+                    (0, '0'),
+                    (0.0, '0.0'),
+                    ('0.000', '0.000'),
+                    (0.001, '0.001'),
+                    ('0.999', '0.999'),
+                    (1, '1'),
+                    (1.0, '1.0'),
+                    ('1.000', '1.000'),
+                ],
+            ),
+
+            # min_value and max_value (as Decimal)
+            *unpack_params(
+                Decimal('-0.5'), Decimal('0.5'),
+                [
+                    (-0.5, '-0.5'),
+                    ('-0.5', '-0.5'),
+                    (0, '0'),
+                    (0.1, '0.1'),
+                    ('0.499', '0.499'),
+                    (0.5, '0.5'),
+                    ('0.500', '0.500'),
+                ],
+            ),
+        ]
+    )
+    def test_value_range_valid(min_value, max_value, input_data, expected_decimal_str):
+        """ Test NumericValidator with different range requirements and different types of input values. """
+        validator = NumericValidator(min_value=min_value, max_value=max_value)
+        output_value = validator.validate(input_data)
+        assert type(output_value) is Decimal
+        assert str(output_value) == expected_decimal_str
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'min_value, max_value, input_data', [
+            # min_value only (as integer)
+            *unpack_params(
+                1, None,
+                [
+                    -1,
+                    '-1.0',
+                    0,
+                    '0.0',
+                    0.999,
+                    '0.99999'
+                ],
+            ),
+
+            # max_value only (as float)
+            *unpack_params(
+                None, 10.0,
+                [
+                    10.001,
+                    '10.001',
+                    11,
+                    12.345,
+                    '999.9',
+                ],
+            ),
+
+            # min_value and max_value (as strings)
+            *unpack_params(
+                '0', '1',
+                [
+                    -1,
+                    -0.001,
+                    '-0.000001',
+                    1.001,
+                    '1.000001',
+                    2,
+                ],
+            ),
+
+            # min_value and max_value (as Decimal)
+            *unpack_params(
+                Decimal('-0.5'), Decimal('0.5'),
+                [
+                    -1,
+                    -0.6,
+                    '-0.500001',
+                    0.500001,
+                    '0.6',
+                    1,
+                ],
+            ),
+        ]
+    )
+    def test_value_range_invalid(min_value, max_value, input_data):
+        """ Test NumericValidator with range requirements with invalid input values. """
+        validator = NumericValidator(min_value=min_value, max_value=max_value)
+
+        with pytest.raises(NumberRangeError) as exception_info:
+            validator.validate(input_data)
+        assert exception_info.value.to_dict() == {
+            'code': 'number_range_error',
+            **({'min_value': str(min_value)} if min_value is not None else {}),
+            **({'max_value': str(max_value)} if max_value is not None else {}),
+        }
+
+    # Test output_places parameter
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'output_places, input_data, expected_decimal_str', [
+            # output_places=0
+            (0, 0.0, '0'),
+            (0, -42.0, '-42'),
+            (0, 42.0, '42'),
+            (0, 123.456, '123'),  # rounded down
+            (0, 123.567, '124'),  # rounded up
+            # output_places=2
+            (2, 0.0, '0.00'),
+            (2, -42.0, '-42.00'),
+            (2, 42.0, '42.00'),
+            (2, 123.454, '123.45'),  # rounded down
+            (2, 123.455, '123.46'),  # rounded up
+        ]
+    )
+    def test_output_places(output_places, input_data, expected_decimal_str):
+        """ Test NumericValidator with output_places parameter (fixed number of decimal places in output value). """
+        validator = NumericValidator(output_places=output_places)
+        assert str(validator.validate(input_data)) == expected_decimal_str
+
+    # Invalid validator parameters
+
+    @staticmethod
+    def test_min_value_greater_than_max_value():
+        """ Check that NumericValidator raises exception when min_value is greater than max_value. """
+        with pytest.raises(InvalidValidatorOptionException) as exception_info:
+            NumericValidator(min_value=2, max_value=1.9)
+        assert str(exception_info.value) == 'Parameter "min_value" cannot be greater than "max_value".'
+
+    @staticmethod
+    def test_output_places_negative():
+        """ Check that NumericValidator raises exception when output_places is less than 0. """
+        with pytest.raises(InvalidValidatorOptionException) as exception_info:
+            NumericValidator(output_places=-1)
+        assert str(exception_info.value) == 'Parameter "output_places" cannot be negative.'


### PR DESCRIPTION
This PR reimplements the `FloatToDecimalValidator` based on the `DecimalValidator` instead of the `FloatValidator`, which simplifies the code a bit and makes `NumberRangeError` exceptions more consistent ("min_value" and "max_value" in the exceptions are now always decimal strings instead of floats or decimals depending on the type of input value).

It also adds the `NumericValidator` as a shortcut for `FloatToDecimalValidator(allow_integers=True, allow_strings=True)`, so it parses floats, integers and decimal strings and always returns Decimals.