### PR TITLE
Split up GitHub workflow to allow test reports from forked repositories

### DIFF
--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -1,0 +1,27 @@
+# GitHub Actions workflow to upload test reports after the tests.yml workflow.
+# (This is a separate workflow in order to allow test reports on forked repositories.)
+
+name: Test reports
+
+on:
+  # Run this workflow automatically after the "Unit tests" workflow has completed.
+  workflow_run:
+    workflows:
+      - "Unit tests"
+    types:
+      - completed
+
+jobs:
+  report:
+    name: Publish unit test reports
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Publish unit test reports
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          artifact: pytest-results
+          name: Pytest Report
+          path: reports/pytest_junit_*.xml
+          reporter: java-junit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,11 @@ jobs:
 
       - name: Run unit tests with tox
         # Run tox using the version of Python in `PATH`
-        run: tox -e clean,py,flake8 -- --junit-xml=reports/pytest_junit.xml
+        run: tox -e clean,py,flake8 -- --junit-xml=reports/pytest_junit_${{ matrix.python-version }}.xml
 
-      - name: Publish unit test results
-        uses: dorny/test-reporter@v1
-        if: always()
+      - name: Upload test results as artifact
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
-          name: Pytest Report (Python ${{ matrix.python-version }})
-          path: reports/pytest_junit.xml
-          reporter: java-junit
-          fail-on-error: false
+          name: pytest-results
+          path: reports/pytest_junit_${{ matrix.python-version }}.xml


### PR DESCRIPTION
This PR should (hopefully) allow the GitHub actions workflow to publish test reports from formed repositories.