### PR TITLE
UrlValidator: Add `allow_empty` and `max_length` parameter

### DIFF
--- a/src/validataclass/validators/url_validator.py
+++ b/src/validataclass/validators/url_validator.py
@@ -77,6 +77,9 @@ class UrlValidator(StringValidator):
     # Whether to allow empty strings to pass
     allow_empty: bool
 
+    # Maximum URL length
+    max_length: int
+
     # Precompiled regular expression
     url_regex: re.Pattern = re.compile(r'''
         (?P<scheme> [a-z][a-z0-9.+-]* )
@@ -94,6 +97,7 @@ class UrlValidator(StringValidator):
         allow_ip: bool = True,
         allow_userinfo: bool = False,
         allow_empty: bool = False,
+        max_length: int = 2000,
     ):
         """
         Create a `UrlValidator` with optional parameters.
@@ -112,7 +116,7 @@ class UrlValidator(StringValidator):
         min_length = 0 if allow_empty else 1
 
         # Initialize StringValidator with some length requirements
-        super().__init__(min_length=min_length, max_length=2000)
+        super().__init__(min_length=min_length, max_length=max_length)
 
         # Save allowed schemes
         if allowed_schemes is None:

--- a/src/validataclass/validators/url_validator.py
+++ b/src/validataclass/validators/url_validator.py
@@ -77,9 +77,6 @@ class UrlValidator(StringValidator):
     # Whether to allow empty strings to pass
     allow_empty: bool
 
-    # Maximum URL length
-    max_length: int
-
     # Precompiled regular expression
     url_regex: re.Pattern = re.compile(r'''
         (?P<scheme> [a-z][a-z0-9.+-]* )
@@ -111,6 +108,7 @@ class UrlValidator(StringValidator):
             allow_ip: `bool`, whether IP addresses are allowed as host (default: True)
             allow_userinfo: `bool`, whether URLs may contain userinfo (default: False)
             allow_empty: `bool`, whether empty strings should pass validation (default: False)
+            max_length: `int`, specifies maximum length of input strings (default: 2000)
         """
         # Set allow_empty and StringValidator's min_length
         min_length = 0 if allow_empty else 1

--- a/tests/validators/url_validator_test.py
+++ b/tests/validators/url_validator_test.py
@@ -34,7 +34,7 @@ class UrlValidatorTest:
 
     @staticmethod
     def test_invalid_empty_string():
-        """ Check that UrlValidator raises exceptions for empty strings. """
+        """ Check that UrlValidator raises exceptions for empty strings by default. """
         validator = UrlValidator()
         with pytest.raises(StringInvalidLengthError) as exception_info:
             validator.validate('')
@@ -257,3 +257,9 @@ class UrlValidatorTest:
             'code': 'invalid_url',
             'reason': error_reason,
         }
+
+    @staticmethod
+    def test_allow_empty_valid():
+        """ Check that UrlValidator with allow_empty=True lets empty string through unchanged. """
+        validator = UrlValidator(allow_empty=True)
+        assert validator.validate("") == ""

--- a/tests/validators/url_validator_test.py
+++ b/tests/validators/url_validator_test.py
@@ -263,3 +263,17 @@ class UrlValidatorTest:
         """ Check that UrlValidator with allow_empty=True lets empty string through unchanged. """
         validator = UrlValidator(allow_empty=True)
         assert validator.validate("") == ""
+
+
+    @staticmethod
+    def test_url_longer_than_max_length_invalid():
+        """ Test UrlValidator with string longer than max_length """
+        validator = UrlValidator(max_length=20)
+        input_data = 21 * "a"
+        with pytest.raises(StringInvalidLengthError) as exception_info:
+            validator.validate(input_data)
+        assert exception_info.value.to_dict() == {
+            'code': 'string_too_long',
+            'min_length': 1,
+            'max_length': 20,
+        }

--- a/tests/validators/url_validator_test.py
+++ b/tests/validators/url_validator_test.py
@@ -264,7 +264,6 @@ class UrlValidatorTest:
         validator = UrlValidator(allow_empty=True)
         assert validator.validate("") == ""
 
-
     @staticmethod
     def test_url_longer_than_max_length_invalid():
         """ Test UrlValidator with string longer than max_length """


### PR DESCRIPTION
This attempts to address #36.