### PR TITLE
IntegerValidator: Default min/max values for 32 bit integers (#42)

### DIFF
--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -268,32 +268,38 @@ The optional parameter `allow_strings` can be set to `True` to allow both intege
 validator will convert strings to integers in that case, so the input values `123` (integer) and `"123"` (string) will
 both result in the integer output value `123`.
 
-Optionally you can also specify a range of valid values using `min_value` and `max_value`.
+Use the parameters `min_value` and/or `max_value` to set a value range (smallest and biggest allowed integer).
+By default, these parameters are set so that only 32 bit integers are allowed, i.e. only integers from -2147483648
+(`-2^32`) to 2147483647 (`2^32 - 1`).
+
+However, these are just default values. To allow integers outside the 32-bit range, simply set `min_value` and
+`max_value` to `None`.
 
 **Examples:**
 
 ```python
 from validataclass.validators import IntegerValidator
 
-# Default: Accepts any integer
+# Default: Accepts any 32-bit integer
 validator = IntegerValidator()
-validator.validate(0)     # will return 0
-validator.validate(123)   # will return 123
-validator.validate(-123)  # will return -123
-validator.validate("1")   # will raise InvalidTypeError (use allow_strings=True or a DecimalValidator)
+validator.validate(0)            # will return 0
+validator.validate(123)          # will return 123
+validator.validate(-123)         # will return -123
+validator.validate("1")          # will raise InvalidTypeError (use allow_strings=True or a DecimalValidator)
+validator.validate(2147483648)   # will raise NumberRangeError(min_value=-2147483648, max_value=2147483647)
+validator.validate(-2147483649)  # will raise NumberRangeError(min_value=-2147483648, max_value=2147483647)
 
-# allow_strings parameter: Accept integers also as strings
-validator = IntegerValidator(allow_strings=True)
-validator.validate(42)      # will return 42
-validator.validate("42")    # will return 42
-validator.validate("-123")  # will return -123
-validator.validate("foo")   # will raise InvalidIntegerError
+# No value limits: Accepts any integer known to Python
+validator = IntegerValidator(min_value=None, max_value=None)
+validator.validate(2147483648)        # will return 2147483648
+validator.validate(-2147483649)       # will return -2147483649
+validator.validate(9999999999999999)  # will return 9999999999999999
 
 # min_value parameter: Only allow zero or positive numbers
 validator = IntegerValidator(min_value=0)
 validator.validate(0)     # will return 0
 validator.validate(123)   # will return 123
-validator.validate(-123)  # will raise NumberRangeError(min_value=0)
+validator.validate(-123)  # will raise NumberRangeError(min_value=0, max_value=2147483647)
 
 # min_value and max_value: Only allow values 1 to 10
 validator = IntegerValidator(min_value=1, max_value=10)
@@ -304,11 +310,18 @@ validator.validate(11)  # will raise NumberRangeError(min_value=1, max_value=10)
 
 # max_value only: Allow all values smaller than or equal to 10
 validator = IntegerValidator(max_value=10)
-validator.validate(1)   # will return 1
-validator.validate(10)  # will return 10
-validator.validate(11)  # will raise NumberRangeError(max_value=10)
+validator.validate(1)      # will return 1
+validator.validate(10)     # will return 10
+validator.validate(11)     # will raise NumberRangeError(min_value=-2147483648, max_value=10)
 # NOTE: This also allows any negative number (because no min_value is specified):
 validator.validate(-1234)  # valid! will return -1234
+
+# allow_strings parameter: Accept integers also as strings
+validator = IntegerValidator(allow_strings=True)
+validator.validate(42)      # will return 42
+validator.validate("42")    # will return 42
+validator.validate("-123")  # will return -123
+validator.validate("foo")   # will raise InvalidIntegerError
 ```
 
 

--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -32,6 +32,7 @@ A much more useful distinction is to categorize the validators according to thei
 
 - Numeric types:
   - `IntegerValidator`: Validates integers (as `int`, not as `str`)
+  - `BigIntegerValidator`: Validates integers (variation of `IntegerValidator`)
   - `FloatValidator`: Validates floats (as `float`, not as `str`)
   - `DecimalValidator`: Validates decimal **strings** (e.g. `"1.23"`) to `decimal.decimal` objects
   - `FloatToDecimalValidator`: Validates floats (e.g. `1.23`) to `decimal.decimal` objects
@@ -273,7 +274,7 @@ By default, these parameters are set so that only 32 bit integers are allowed, i
 (`-2^32`) to 2147483647 (`2^32 - 1`).
 
 However, these are just default values. To allow integers outside the 32-bit range, simply set `min_value` and
-`max_value` to `None`.
+`max_value` to `None`. See also the `BigIntegerValidator` below.
 
 **Examples:**
 
@@ -322,6 +323,51 @@ validator.validate(42)      # will return 42
 validator.validate("42")    # will return 42
 validator.validate("-123")  # will return -123
 validator.validate("foo")   # will raise InvalidIntegerError
+```
+
+
+### BigIntegerValidator
+
+The `BigIntegerValidator` is a variation of the `IntegerValidator` with other default parameters.
+
+It's exactly the same validator, just without the default values for `min_value` and `max_value` set by the regular
+`IntegerValidator`, thus allowing arbitrarily big integers by default.
+
+Basically, `BigIntegerValidator()` is a shorthand for `IntegerValidator(min_value=None, max_value=None)`.
+
+You can still set `min_value` and/or `max_value` with this validator, e.g. to restrict input to positive integers.
+If you need to set both parameters, you should use the regular `IntegerValidator` instead, since there is no point in
+using the `BigIntegerValidator` then.
+
+Like the IntegerValidator, it also supports the parameter `allow_strings` to allow strings as input.
+
+**Examples:**
+
+```python
+from validataclass.validators import BigIntegerValidator
+
+# Default: Accepts any integer
+validator = BigIntegerValidator()
+validator.validate(0)                # will return 0
+validator.validate(123)              # will return 123
+validator.validate(-123)             # will return -123
+validator.validate(99999999999999)   # will return 99999999999999
+validator.validate(-99999999999999)  # will return -99999999999999
+validator.validate("1")              # will raise InvalidTypeError
+
+# min_value parameter: Only allow zero or positive numbers
+validator = BigIntegerValidator(min_value=0)
+validator.validate(0)               # will return 0
+validator.validate(123)             # will return 123
+validator.validate(99999999999999)  # will return 99999999999999
+validator.validate(-123)            # will raise NumberRangeError(min_value=0, max_value=2147483647)
+
+# allow_strings parameter: Accept integers also as strings
+validator = BigIntegerValidator(allow_strings=True)
+validator.validate(42)                 # will return 42
+validator.validate("99999999999999")   # will return 99999999999999
+validator.validate("-99999999999999")  # will return -99999999999999
+validator.validate("foo")              # will raise InvalidIntegerError
 ```
 
 

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -18,6 +18,7 @@ from .noneable import Noneable
 
 # Extended type validators
 from .any_of_validator import AnyOfValidator
+from .big_integer_validator import BigIntegerValidator
 from .enum_validator import EnumValidator
 from .decimal_validator import DecimalValidator
 from .float_to_decimal_validator import FloatToDecimalValidator

--- a/src/validataclass/validators/big_integer_validator.py
+++ b/src/validataclass/validators/big_integer_validator.py
@@ -1,0 +1,61 @@
+"""
+validataclass
+Copyright (c) 2021, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from typing import Optional
+
+from .integer_validator import IntegerValidator
+
+__all__ = [
+    'BigIntegerValidator',
+]
+
+
+class BigIntegerValidator(IntegerValidator):
+    """
+    Validator for big integer values.
+
+    This validator is a variation of the IntegerValidator. It's exactly the same validator, just with other default
+    parameters.
+
+    While the IntegerValidator sets defaults for `min_value` and `max_value` to limit input to 32-bit integers, the
+    BigIntegerValidator resets these parameters to `None` to allow arbitrarily big integers. You can still override
+    these parameters, e.g. by setting `min_value=1` to allow only positive numbers.
+
+    So basically, `BigIntegerValidator()` is identical to `IntegerValidator(min_value=None, max_value=None)`.
+
+    Like the IntegerValidator, it also supports the parameter `allow_strings` to allow strings as input.
+
+    Examples:
+
+    ```
+    # Accepts *any* integer (e.g. -1000000000000000, 123, 1000000000000000, but not a string like "123")
+    BigIntegerValidator()
+
+    # Accepts only positive integers (e.g. 123, 1000000000000000, but not 0 or -1)
+    BigIntegerValidator(min_value=1)
+
+    # Accepts only values in the specified range. There is no point in using the BigIntegerValidator in this case, as
+    # it's identical to an IntegerValidator with the same parameters, so you should use that one instead.
+    BigIntegerValidator(min_value=-100, max_value=100)
+
+    # Accepts any integer either as a direct integer or a numeric string (e.g. "1000000000000000" -> 1000000000000000)
+    BigIntegerValidator(allow_strings=True)
+    ```
+
+    Valid input: `int` (also `str` if `allow_strings=True`)
+    Output: `int`
+    """
+
+    def __init__(self, *, min_value: Optional[int] = None, max_value: Optional[int] = None, allow_strings: bool = False):
+        """
+        Create a BigIntegerValidator.
+
+        Parameters:
+            min_value: Integer or None, smallest allowed integer value (default: None, no limit)
+            max_value: Integer or None, biggest allowed integer value (default: None, no limit)
+            allow_strings: Boolean, if True, numeric strings (e.g. "123") are accepted and converted to integers (default: False)
+        """
+        super().__init__(min_value=min_value, max_value=max_value, allow_strings=allow_strings)

--- a/src/validataclass/validators/integer_validator.py
+++ b/src/validataclass/validators/integer_validator.py
@@ -18,23 +18,33 @@ class IntegerValidator(Validator):
     """
     Validator for integer values, optionally with value range requirements.
 
+    Use the parameters `min_value` and/or `max_value` to set a value range (smallest and biggest allowed integer).
+    By default, these parameters are set so that only 32 bit integers are allowed, i.e. only integers from -2147483648
+    (-2^32) to 2147483647 (2^32 - 1).
+
+    However, these are just default values. To allow integers outside the 32 bit range, set `min_value` and `max_value`
+    to `None`.
+
     By default, only actual integer values (no strings) are allowed. Use the parameter `allow_strings=True` to allow
     numeric strings, e.g. the strings "-123" and "123" would be accepted and automatically converted to integers.
 
     Examples:
 
     ```
-    # Accepts any integer (e.g. -123456, 0, 123456, but not a string like "123")
+    # Accepts any 32 bit integer (e.g. -123456, 0, 123456, but not a string like "123")
     IntegerValidator()
 
-    # Accepts numeric strings, which will be converted to integers (e.g. "1234" -> 1234; "-123" -> -123)
-    IntegerValidator(allow_strings=True)
+    # Accepts any integer known to Python (e.g. -2147483649 and 2147483648, which would not be accepted by default)
+    IntegerValidator(min_value=None, max_value=None)
 
     # Only accepts zero or positive numbers
     IntegerValidator(min_value=0)
 
     # Only accepts values 1 to 10 (including the numbers 1 and 10)
     IntegerValidator(min_value=1, max_value=10)
+
+    # Accepts numeric strings, which will be converted to integers (e.g. "1234" -> 1234; "-123" -> -123)
+    IntegerValidator(allow_strings=True)
     ```
 
     Note: While it is allowed to set `max_value` without setting `min_value`, this might not do what you expect. For example,
@@ -45,6 +55,10 @@ class IntegerValidator(Validator):
     Output: `int`
     """
 
+    # Constants (minimum and maximum values for a 32 bit integer)
+    DEFAULT_MIN_VALUE = -2147483648  # -2^32
+    DEFAULT_MAX_VALUE = 2147483647  # 2^32 - 1
+
     # Value constraints
     min_value: Optional[int] = None
     max_value: Optional[int] = None
@@ -52,13 +66,18 @@ class IntegerValidator(Validator):
     # Whether to allow integers as strings
     allow_strings: bool = False
 
-    def __init__(self, *, min_value: Optional[int] = None, max_value: Optional[int] = None, allow_strings: bool = False):
+    def __init__(
+        self, *,
+        min_value: Optional[int] = DEFAULT_MIN_VALUE,
+        max_value: Optional[int] = DEFAULT_MAX_VALUE,
+        allow_strings: bool = False,
+    ):
         """
         Create a IntegerValidator with optional value range.
 
         Parameters:
-            min_value: Integer, specifies lowest value an input integer may have (default: None, no minimum value)
-            max_value: Integer, specifies highest value an input integer may have (default: None, no maximum value)
+            min_value: Integer or None, smallest allowed integer value (default: IntegerValidator.DEFAULT_MIN_VALUE = -2147483648)
+            max_value: Integer or None, biggest allowed integer value (default: IntegerValidator.DEFAULT_MAX_VALUE = 2147483647)
             allow_strings: Boolean, if True, numeric strings (e.g. "123") are accepted and converted to integers (default: False)
         """
         # Check parameter validity

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,3 +65,7 @@ def unpack_params(*args) -> List[tuple]:
         else:
             unpacked = [(*current_params, arg) for current_params in unpacked]
     return unpacked
+
+
+# This is a sentinel object used in parametrized tests to represent "this parameter should not be set"
+UNSET_PARAMETER = object()

--- a/tests/validators/big_integer_validator_test.py
+++ b/tests/validators/big_integer_validator_test.py
@@ -1,0 +1,133 @@
+"""
+validataclass
+Copyright (c) 2021, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+import pytest
+
+from validataclass.exceptions import RequiredValueError, InvalidTypeError, NumberRangeError
+from validataclass.validators import BigIntegerValidator
+
+
+class BigIntegerValidatorTest:
+    """
+    Unit tests for BigIntegerValidator.
+    """
+
+    # General tests
+
+    @staticmethod
+    def test_invalid_none():
+        """ Check that BigIntegerValidator raises exceptions for None as value. """
+        validator = BigIntegerValidator()
+        with pytest.raises(RequiredValueError) as exception_info:
+            validator.validate(None)
+        assert exception_info.value.to_dict() == {'code': 'required_value'}
+
+    @staticmethod
+    @pytest.mark.parametrize('input_data', ['banana', '1234', 1.234, True])
+    def test_invalid_wrong_type(input_data):
+        """ Check that BigIntegerValidator raises exceptions for values that are not of type 'int'. """
+        validator = BigIntegerValidator()
+        with pytest.raises(InvalidTypeError) as exception_info:
+            validator.validate(input_data)
+        assert exception_info.value.to_dict() == {
+            'code': 'invalid_type',
+            'expected_type': 'int',
+        }
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data',
+        [
+            -10000000000000000000,
+            -2147483648,
+            0,
+            123,
+            2147483647,
+            10000000000000000000,
+        ]
+    )
+    def test_without_value_range(input_data):
+        """ Test the BigIntegerValidator with the default min_value and max_value (i.e. no limit). """
+        validator = BigIntegerValidator()
+        assert validator.validate(input_data) == input_data
+
+    # Tests with min_value
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data',
+        [
+            100,
+            2147483647,
+            10000000000000000000,
+        ]
+    )
+    def test_with_min_value_valid(input_data):
+        """ Test the BigIntegerValidator with the min_value parameter for valid input. """
+        validator = BigIntegerValidator(min_value=100)
+        assert validator.validate(input_data) == input_data
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data',
+        [
+            -10000000000000000000,
+            -2147483648,
+            0,
+            99,
+        ]
+    )
+    def test_with_min_value_invalid(input_data):
+        """ Test the BigIntegerValidator with the min_value parameter for invalid input. """
+        validator = BigIntegerValidator(min_value=100)
+
+        with pytest.raises(NumberRangeError) as exception_info:
+            validator.validate(input_data)
+
+        assert exception_info.value.to_dict() == {
+            'code': 'number_range_error',
+            'min_value': 100,
+        }
+
+    # Tests with min_value and max_value
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data',
+        [
+            100,
+            999,
+            1000,
+        ]
+    )
+    def test_with_min_and_max_value_valid(input_data):
+        """ Test the BigIntegerValidator with min_value and max_value for valid input. """
+        validator = BigIntegerValidator(min_value=100, max_value=1000)
+        assert validator.validate(input_data) == input_data
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data',
+        [
+            -1000000000000000,
+            0,
+            99,
+            1001,
+            1000000000000000,
+        ]
+    )
+    def test_with_min_and_max_value_invalid(input_data):
+        """ Test the BigIntegerValidator with min_value and max_value for invalid input. """
+        validator = BigIntegerValidator(min_value=100, max_value=1000)
+
+        with pytest.raises(NumberRangeError) as exception_info:
+            validator.validate(input_data)
+
+        assert exception_info.value.to_dict() == {
+            'code': 'number_range_error',
+            'min_value': 100,
+            'max_value': 1000,
+        }


### PR DESCRIPTION
This PR sets defaults for `min_value` and `max_value` of the `IntegerValidator` to limit input by default to 32-bit integers, according to #42.

_Technically_ this is a breaking change, but it's unlikely that it causes problems (also, we are still at version 0.x anyway).