### PR TITLE
Noneable: Raise exception if wrapped validator has invalid type (#38)

### DIFF
--- a/src/validataclass/validators/noneable.py
+++ b/src/validataclass/validators/noneable.py
@@ -7,8 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 from copy import deepcopy
 from typing import Any, Optional
 
-from .validator import Validator
 from validataclass.exceptions import InvalidTypeError
+from .validator import Validator
 
 __all__ = [
     'Noneable',
@@ -17,17 +17,21 @@ __all__ = [
 
 class Noneable(Validator):
     """
-    Helper validator that wraps another validator but allows `None` as input value.
+    Meta validator that wraps another validator, but allows `None` as input value.
 
-    By default, the wrapper returns `None` for `None` as input value. Optionally a default value can be specified in the constructor
-    that will be returned instead of `None`.
+    By default, the wrapper returns `None` for `None` as input value. Optionally a default value can be specified in the
+    constructor that will be returned instead of `None`.
 
-    If the wrapped validator raises an `InvalidTypeError`, `Noneable` will add 'none' to its 'expected_types' parameter and reraise it.
+    If the wrapped validator raises an `InvalidTypeError`, `Noneable` will add 'none' to its 'expected_types' parameter
+    and reraise it.
 
     Examples:
 
     ```
+    # Accepts strings and None, returns both unmodified (e.g. "foo" -> "foo", "" -> "", None -> None)
     Noneable(StringValidator())
+
+    # Accepts strings and None, returns a default string for None (e.g. None -> "no value given!", but "" -> "")
     Noneable(StringValidator(), default='no value given!')
     ```
 
@@ -42,10 +46,27 @@ class Noneable(Validator):
     wrapped_validator: Validator
 
     def __init__(self, validator: Validator, *, default: Any = None):
+        """
+        Create a Noneable meta validator.
+
+        Parameters:
+            validator: Validator that will be wrapped (required)
+            default: Value of any type that is returned instead of None (default: None)
+        """
+        # Check parameter validity
+        if not isinstance(validator, Validator):
+            raise TypeError('Noneable requires a Validator instance.')
+
         self.wrapped_validator = validator
         self.default_value = default
 
     def validate(self, input_data: Any) -> Optional[Any]:
+        """
+        Validate input data.
+
+        If the input is None, return None (or the value specified in the `default` parameter). Otherwise, pass the input
+        to the wrapped validator and return its result.
+        """
         if input_data is None:
             return deepcopy(self.default_value)
 


### PR DESCRIPTION
This PR implements a type check on construction for the `Noneable` meta validator.

Resolves #38.