### PR TITLE
RegexValidator: Add support for custom exception classes (#44)

### DIFF
--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -144,15 +144,22 @@ validator.validate("foo\0")       # will return "foo\0" (with ASCII null-byte)
 
 The `RegexValidator` uses a custom regular expression to validate strings.
 
-The regex can be specified either as a precompiled pattern (see `re.compile()`) or as a string which will be compiled by the class.
-Regex flags (e.g. `re.IGNORECASE` for case-insensitive matching) can only be set by precompiling a pattern with those flags.
+The regex can be specified either as a precompiled pattern (see `re.compile()`) or as a string which will be compiled by
+the class. Regex flags (e.g. `re.IGNORECASE` for case-insensitive matching) can only be set by precompiling a pattern
+with those flags.
 
-The input string will then be matched against the regex using `re.fullmatch()`, which means that the **full** string must match the regex.
-
-This validator is based on the `StringValidator` (see above) and accepts all of its parameters, so you can use `min_length`, `multiline`,
-etc. just like with the `StringValidator` (the same default values are applied here).
+The input string will then be matched against the regex using `re.fullmatch()`, which means that the **full** string
+must match the regex.
 
 For further information on regular expressions, see: https://docs.python.org/3/library/re.html
+
+This validator is based on the `StringValidator` (see above) and accepts all of its parameters, so you can use
+`min_length`, `multiline`, etc. just like with the `StringValidator` (the same default values are applied here).
+
+If the input string does not match the regex, a `RegexMatchError` validation error with the default error code
+'invalid_string_format' is raised. To get more explicit error messages, you can specify a custom validation error
+using the parameters `custom_error_class` (which must be a subclass of `ValidationError`) and/or `custom_error_code`
+(which is a string that overrides the default error code).
 
 **Examples:**
 
@@ -181,6 +188,15 @@ validator.validate("123Abcdef")  # will raise StringTooLongError
 # Same example, but setting a custom error code
 validator = RegexValidator(re.compile(r'[0-9a-f]+'), custom_error_code='invalid_hex_number')
 validator.validate("banana")  # will raise RegexMatchError, but with code='invalid_hex_number'
+
+# Define a custom exception class instead of just setting a custom error code
+from validataclass.exceptions import ValidationError
+
+class InvalidHexNumberError(ValidationError):
+    code = 'invalid_hex_number'
+
+validator = RegexValidator(re.compile(r'[0-9a-f]+'), custom_error_class=InvalidHexNumberError)
+validator.validate("banana")  # will raise a InvalidHexNumberError with its defined error code
 ```
 
 

--- a/src/validataclass/validators/regex_validator.py
+++ b/src/validataclass/validators/regex_validator.py
@@ -5,10 +5,10 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 import re
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Type
 
+from validataclass.exceptions import RegexMatchError, ValidationError
 from .string_validator import StringValidator
-from validataclass.exceptions import RegexMatchError
 
 __all__ = [
     'RegexValidator',
@@ -17,22 +17,25 @@ __all__ = [
 
 class RegexValidator(StringValidator):
     """
-    Validator that matches strings against a specified regular expression, optionally with minimal/maximal length requirements.
+    Validator that matches strings against a regular expression, optionally with minimal/maximal length requirements.
 
     This validator is based on the `StringValidator` which first handles type checking and optional length requirements.
-    The input string is then matched against the regex using `re.fullmatch()` from the Python standard library, which means that the
-    *full* string must match the regex.
+    The input string is then matched against the regex using `re.fullmatch()` from the Python standard library, which
+    means that the *full* string must match the regex.
 
-    The regex can be specified either as a precompiled pattern (see `re.compile()`) or as a string which will be compiled by the class.
-    Regex flags (e.g. `re.IGNORECASE` for case-insensitive matching) can only be set by precompiling a pattern with those flags.
+    The regex can be specified either as a precompiled pattern (see `re.compile()`) or as a string which will be
+    compiled by the class. Regex flags (e.g. `re.IGNORECASE` for case-insensitive matching) can only be set by
+    precompiling a pattern with those flags.
 
     For further information on regular expressions, see: https://docs.python.org/3/library/re.html
 
-    If the input string does not match the regex, a `RegexMatchError` validation error with the error code 'invalid_string_format' is
-    raised. The error code can be overridden with the 'custom_error_code' parameter to get more explicit error messages.
+    If the input string does not match the regex, a `RegexMatchError` validation error with the default error code
+    'invalid_string_format' is raised. To get more explicit error messages, you can specify a custom validation error
+    using the parameters `custom_error_class` (which must be a subclass of `ValidationError`) and/or `custom_error_code`
+    (which is a string that overrides the default error code).
 
-    By default only "safe" singleline strings are allowed (i.e. no non-printable characters). See the `StringValidator` options 'unsafe'
-    and 'multiline' for more details.
+    By default only "safe" singleline strings are allowed (i.e. no non-printable characters). See the `StringValidator`
+    options `unsafe` and `multiline` for more details.
 
     Examples:
 
@@ -52,8 +55,14 @@ class RegexValidator(StringValidator):
     # As above, but setting string length requirements to only allow 6-digit hex numbers (e.g. '123abc')
     RegexValidator(re.compile(r'[0-9a-f]+', re.IGNORECASE), min_length=6, max_length=6)
 
-    # Set a custom error code (on error, validator will raise RegexMatchError with dict representation {'code': 'invalid_hex_number'})
+    # Set a custom error code (will raise RegexMatchError with error code 'invalid_hex_number' on error)
     RegexValidator(re.compile(r'[0-9a-f]+'), custom_error_code='invalid_hex_number')
+
+    # Set a custom error class (will raise this exception with its default error code on error)
+    class InvalidHexNumberError(RegexMatchError):
+        code = 'invalid_hex_number'
+
+    RegexValidator(re.compile(r'[0-9a-f]+'), custom_error_class=InvalidHexNumberError)
     ```
 
     Valid input: Any `str` that matches the regex
@@ -63,18 +72,37 @@ class RegexValidator(StringValidator):
     # Precompiled regex pattern
     regex_pattern: re.Pattern
 
-    # Error code to use in RegexMatchError exception (use default if None)
-    custom_error_code: Optional[str] = None
+    # Exception class to use when regex matching fails
+    custom_error_class: Type[ValidationError]
 
-    def __init__(self, pattern: Union[re.Pattern, str], *, custom_error_code: Optional[str] = None, **kwargs):
+    # Custom error code to use in the regex match exception (use default if None)
+    custom_error_code: Optional[str]
+
+    def __init__(
+        self,
+        pattern: Union[re.Pattern, str],
+        *,
+        custom_error_class: Type[ValidationError] = RegexMatchError,
+        custom_error_code: Optional[str] = None,
+        **kwargs,
+    ):
         """
         Create a RegexValidator with a specified regex pattern (as string or precompiled `re.Pattern` object).
 
-        Optionally with a custom error code. Other keyword arguments (e.g. 'min_length', 'max_length', 'multiline' and 'unsafe') will be
-        passed to `StringValidator`.
+        Optionally with a custom error class (subclass of ValidationError) and custom error code. Other keyword
+        arguments (e.g. 'min_length', 'max_length', 'multiline' and 'unsafe') will be passed to `StringValidator`.
+
+        Parameters:
+            pattern: `re.Pattern` or `str`, regex pattern to use for validation (required)
+            custom_error_class: Subclass of `ValidationError` raised when regex matching fails (default: RegexMatchError)
+            custom_error_code: Optional `str`, overrides the default error code in the regex match exception (default: None)
         """
         # Initialize base StringValidator (may set min_length/max_length via kwargs)
         super().__init__(**kwargs)
+
+        # Check parameter validity
+        if not issubclass(custom_error_class, ValidationError):
+            raise TypeError('Custom error class must be a subclass of ValidationError.')
 
         # Save regex pattern (precompile if necessary)
         if isinstance(pattern, re.Pattern):
@@ -82,9 +110,9 @@ class RegexValidator(StringValidator):
         else:
             self.regex_pattern = re.compile(pattern)
 
-        # Save custom error code
-        if custom_error_code is not None:
-            self.custom_error_code = custom_error_code
+        # Save custom error class and code
+        self.custom_error_class = custom_error_class
+        self.custom_error_code = custom_error_code
 
     def validate(self, input_data: Any) -> str:
         """
@@ -95,6 +123,6 @@ class RegexValidator(StringValidator):
 
         # Match full string against Regex pattern
         if not self.regex_pattern.fullmatch(input_data):
-            raise RegexMatchError(code=self.custom_error_code)
+            raise self.custom_error_class(code=self.custom_error_code)
 
         return input_data


### PR DESCRIPTION
This PR adds a parameter to specify a custom exception class in the `RegexValidator`, see #44.

I decided against renaming the existing `custom_error_code` parameter and simply named the new parameter `custom_error_class` as well, to avoid an unnecessary breaking change.