### PR TITLE
New validator: RejectValidator

### DIFF
--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -52,7 +52,7 @@ A much more useful distinction is to categorize the validators according to thei
   - `DictValidator`: Validates **dicts**, validating each field with specified **field validators**
   - `DataclassValidator`: Validates **dicts** to dataclasses, using **field validators** that are defined in the dataclass
 
-- Meta validators:
+- Special validators:
   - `Noneable`: Wraps another validator but allows the input to be `None`
   - `RejectValidator`: Rejects any input with a validation error (except for `None` if allowed)
 
@@ -945,29 +945,32 @@ As these validators are a bit more complex than those that we've seen before, we
 But before we go on with them, we have another special type of validators left.
 
 
-## Meta validators
+## Special validators
 
-Meta validators are a special category of validators. They don't validate anything on their own, instead they wrap one or more other
-validators and then "decide" which one to use for a given input value (or whether to validate it at all), e.g. by looking at the type
-of the input data.
+There are a handful of validators that don't fit into the other categories and have special purposes.
 
-Currently only the `Noneable` meta validator exists, but more are planned to be added in a future version.
+These special validators most of the time don't validate that much on their own. For example, the `AnythingValidator` _(to be implemented!)_
+and `RejectValidator` are special validators that accept/reject any input (with only a few configurable exceptions). 
+
+Some special validators are wrappers around other validators, for example the `Noneable` wrapper that allows `None` as
+input value and passes all other values to the wrapped validator, or the `MultiTypeValidator` _(to be implemented!)_
+that uses one of multiple wrapped validators depending on the type of input data.
 
 
 ### Noneable
 
-The `Noneable` meta validator wraps another validator and additionally allows `None` as an input value.
+The `Noneable` validator wraps another validator and additionally allows `None` as an input value.
 
-Most validators do not allow `None` as the input value and raise an `RequiredValueError` instead. To allow a value to be `None`, the
-`Noneable` meta validator can be used.
+Most validators do not allow `None` as input and raise an `RequiredValueError` instead. To allow the value to be `None`,
+the `Noneable` wrapper can be used.
 
-It first checks if the input value is `None`, in which case it will simply return `None`. In all other cases the input will be passed
-to the wrapped validator as if it was used without `Noneable`.
+It first checks if the input value is `None`, in which case it simply returns `None`. In all other cases the input will
+be passed to the wrapped validator as if it was used without `Noneable`.
 
-Optionally a custom default value can be specified with the `default` parameter. If set, the `Noneable` validator will return this
-default value instead of `None` when the input value is `None`.
+Optionally a custom default value can be specified with the `default` parameter. If set, the `Noneable` validator
+returns this default value instead of `None` when the input value is `None`.
 
-Additionally, if the wrapped validator raises an `InvalidTypeError`, the meta validator will add `"none"` to the `expected_types`
+Additionally, if the wrapped validator raises an `InvalidTypeError`, the wrapper will add `"none"` to the `expected_types`
 parameter of the exception.
 
 **Examples:**

--- a/docs/04-lists-and-dicts.md
+++ b/docs/04-lists-and-dicts.md
@@ -135,7 +135,7 @@ When validating input data, the `DictValidator` first ensures that the input dat
 and that all keys of the dictionary are strings (see note below). It further checks if any **required field** is missing in the input
 dictionary. Then it iterates over all fields in the dictionary. If a field validator is defined for a field, the field **value** will
 be validated using this field validator. Otherwise, the **default validator** will be used. If no default validator is defined, the field
-will be **silently discarded** (i.e. it does not result in a validation error). The output of the `DictValidator` will be new dictionary
+will be **silently discarded** (i.e. it does not result in a validation error). The output of the `DictValidator` will be a new dictionary
 containing the same fields of the input dictionary (except those that were discarded) with the values being the output of the field
 (or default) validators.
 
@@ -152,7 +152,7 @@ DictValidator](06-build-your-own.md) for your usecase.
 **Examples:**
 
 ```python
-from validataclass.validators import DictValidator, IntegerValidator, StringValidator, DecimalValidator
+from validataclass.validators import DictValidator, IntegerValidator, StringValidator, DecimalValidator, RejectValidator
 
 # Validate a dictionary with three fields: "id" (integer), "name" (string), "price" (non-negative Decimal).
 # All three fields are required, since neither required_fields nor optional_fields was set explicitly.
@@ -207,6 +207,16 @@ validator = DictValidator(
 validator.validate({'id': 3, 'foo': '1.2', 'bar': '0.5'})    # returns {'id': 3, 'foo': Decimal('1.2'), 'bar': Decimal('0.5')}
 validator.validate({'foo': '1.2', 'bar': '0.5'})             # raises DictFieldsValidationError (with DictRequiredFieldError for 'id')
 validator.validate({'id': '3', 'foo': '1.2', 'bar': '0.5'})  # raises DictFieldsValidationError (with InvalidTypeError for 'id')
+
+# Without a default validator, unknown fields are silently discarded. If you explicitly want to *reject* unknown fields,
+# use a RejectValidator as the default validator.
+validator = DictValidator(
+    field_validators={'id': IntegerValidator()},
+    default_validator=RejectValidator(),
+)
+
+validator.validate({'id': 42})                   # returns {'id': 42}
+validator.validate({'id': 42, 'foo': 'banana'})  # raises DictFieldsValidationError (with FieldNotAllowedError for 'foo')
 ```
 
 

--- a/docs/05-dataclasses.md
+++ b/docs/05-dataclasses.md
@@ -417,8 +417,8 @@ whether the field was literally an empty string.
 
 One solution is to use `Default(None)` instead: If the field is `None`, you know that the field did not exist in the input dictionary.
 
-This is sufficient in a lot of cases, but sometimes `None` is an allowed value for a field (e.g. when using the `Noneable` meta validator)
-and you need to distinguish between "the field did not exist" and "the field was explicitly set to `None`".
+This is sufficient in a lot of cases, but sometimes `None` is an allowed value for a field (e.g. when using the `Noneable`
+wrapper) and you need to distinguish between "the field did not exist" and "the field was explicitly set to `None`".
 
 For this case, we defined a special value called `UnsetValue`, which you can use similarly to `None`. These values are so called
 [sentinel objects](https://python-patterns.guide/python/sentinel-object/): Their purpose is to represent a missing value. They also are
@@ -488,14 +488,14 @@ For example, imagine a dataclass with only one field: `some_var: Optional[int] =
 dictionary  `{}` would result in an object with the default value `some_var = None`, but the input dictionary `{"some_var": None}` itself
 would **not** be valid at all.
 
-Instead, to explicitly allow `None` as value, you can use the `Noneable` meta validator (introduced [earlier](03-basic-validators.md)),
+Instead, to explicitly allow `None` as value, you can use the `Noneable` wrapper (introduced [earlier](03-basic-validators.md)),
 e.g. `some_var: Optional[int] = Noneable(IntegerValidator())`. This however does **not** make the field optional, so an input dictionary
 with the value `None` would be allowed, but omitting the field in an input dictionary would be invalid.
 
 To make a field both optional **and** allow `None` as value, you can simply combine `Noneable()` and a `Default` value. \
 For example: `some_var: Optional[int] = Noneable(IntegerValidator()), Default(None)`.
 
-You can also configure the `Noneable` meta validator to use a different default value than `None`. For example, to always use `0` as the
+You can also configure the `Noneable` wrapper to use a different default value than `None`. For example, to always use `0` as the
 default value, regardless of whether the field is missing in the input dictionary or whether the field has the input value `None`: \
 `some_var: int = Noneable(IntegerValidator(), default=0), Default(0)`.
 

--- a/src/validataclass/exceptions/__init__.py
+++ b/src/validataclass/exceptions/__init__.py
@@ -8,7 +8,13 @@ Use of this source code is governed by an MIT-style license that can be found in
 from .meta_exceptions import InvalidValidatorOptionException, DataclassValidatorFieldException
 
 # Base and common validation error exceptions (base class ValidationError)
-from .common_exceptions import ValidationError, InternalValidationError, InvalidTypeError, RequiredValueError
+from .common_exceptions import (
+    ValidationError,
+    RequiredValueError,
+    FieldNotAllowedError,
+    InternalValidationError,
+    InvalidTypeError,
+)
 
 # More specific validation errors
 from .dataclass_exceptions import DataclassPostValidationError

--- a/src/validataclass/exceptions/common_exceptions.py
+++ b/src/validataclass/exceptions/common_exceptions.py
@@ -9,6 +9,7 @@ from typing import Union, Optional, Dict, List
 __all__ = [
     'ValidationError',
     'RequiredValueError',
+    'FieldNotAllowedError',
     'InvalidTypeError',
     'InternalValidationError',
 ]
@@ -76,6 +77,16 @@ class RequiredValueError(ValidationError):
     Validation error raised when None is passed as input data (unless using `Noneable`).
     """
     code = 'required_value'
+
+
+class FieldNotAllowedError(ValidationError):
+    """
+    Validation error raised by the `RejectValidator` for any input data (except for `None` if allowed by the validator).
+
+    In practice, this error mostly is raised when the user specifies an input value for a field in a validataclass that
+    uses a `RejectValidator` (e.g. because the user is not allowed to set this field).
+    """
+    code = 'field_not_allowed'
 
 
 class InvalidTypeError(ValidationError):

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -13,7 +13,7 @@ from .integer_validator import IntegerValidator
 from .float_validator import FloatValidator
 from .string_validator import StringValidator
 
-# Meta validators / helpers
+# Special validators
 from .noneable import Noneable
 from .reject_validator import RejectValidator
 

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -15,6 +15,7 @@ from .string_validator import StringValidator
 
 # Meta validators / helpers
 from .noneable import Noneable
+from .reject_validator import RejectValidator
 
 # Extended type validators
 from .any_of_validator import AnyOfValidator

--- a/src/validataclass/validators/noneable.py
+++ b/src/validataclass/validators/noneable.py
@@ -17,7 +17,7 @@ __all__ = [
 
 class Noneable(Validator):
     """
-    Meta validator that wraps another validator, but allows `None` as input value.
+    Special validator that wraps another validator, but allows `None` as input value.
 
     By default, the wrapper returns `None` for `None` as input value. Optionally a default value can be specified in the
     constructor that will be returned instead of `None`.
@@ -47,7 +47,7 @@ class Noneable(Validator):
 
     def __init__(self, validator: Validator, *, default: Any = None):
         """
-        Create a Noneable meta validator.
+        Create a Noneable wrapper validator.
 
         Parameters:
             validator: Validator that will be wrapped (required)

--- a/src/validataclass/validators/reject_validator.py
+++ b/src/validataclass/validators/reject_validator.py
@@ -1,0 +1,104 @@
+"""
+validataclass
+Copyright (c) 2022, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from typing import Any, Optional, Type
+
+from validataclass.exceptions import ValidationError, FieldNotAllowedError
+from .validator import Validator
+
+__all__ = [
+    'RejectValidator',
+]
+
+
+class RejectValidator(Validator):
+    """
+    Meta validator that rejects any input data with a validation error.
+
+    This validator can be used for example in dataclasses to define a field that may never be set, or to override an
+    existing field in a subclassed dataclass that may not be set in this subclass. Keep in mind that in a dataclass
+    you still need to define a default value for this field, e.g. with `DefaultUnset` or `Default(None)`, otherwise you
+    have a dataclass with a field that is required but can never be valid.
+
+    By default, the validator literally rejects anything. In some cases you may want to allow `None` as the only valid
+    input value. This can be done by setting the parameter `allow_none=True`. In that case, the validator returns `None`
+    if `None` is the input value, and rejects anything else.
+
+    The validator raises a `FieldNotAllowedError` by default. Optionally you can set a custom exception class using
+    the parameter `error_class` (must be a subclass of `ValidationError`). There are also the parameters `error_code`
+    to override the default error code with a custom one, and `error_reason` to specify a detailed error message for
+    the user.
+
+    Examples:
+
+    ```
+    # Rejects any input with a FieldNotAllowedError (including None)
+    RejectValidator()
+
+    # Accepts None as the only value, rejects anything else with a FieldNotAllowedError
+    RejectValidator(allow_none=True)
+
+    # Set custom error codes and reasons (but still raises FieldNotAllowedError exceptions)
+    RejectValidator(error_code='custom_error_code')
+    RejectValidator(error_reason='This field cannot be changed.')
+
+    # Set a custom error class (will raise this exception with its default error code on error)
+    class CustomValidationError(ValidationError):
+        code = 'custom_error_code'
+
+    RejectValidator(error_class=CustomValidationError)
+    RejectValidator(error_class=CustomValidationError, error_code='other_error_code')
+    RejectValidator(error_class=CustomValidationError, error_reason='This field cannot be changed.')
+    ```
+
+    Valid input: Nothing (`None` if allow_none=True)
+    Output: Never returns (`None` if allow_none=True)
+    """
+
+    # Whether to allow None as the only valid input
+    allow_none: bool
+
+    # Validation error to raise when rejecting input
+    error_class: Type[ValidationError]
+    error_code: Optional[str]
+    error_reason: Optional[str]
+
+    def __init__(
+        self, *,
+        allow_none: bool = False,
+        error_class: Type[ValidationError] = FieldNotAllowedError,
+        error_code: Optional[str] = None,
+        error_reason: Optional[str] = None,
+    ):
+        """
+        Create a RejectValidator that rejects any input.
+
+        Parameters:
+            allow_none: `bool`, if True, the validator excepts `None` as the only valid input (default: False)
+            error_class: Subclass of `ValidationError` that is raised by the validator (default: `FieldNotAllowedError`)
+            error_code: `str`, optionally overrides the default error code of the error class (default: None)
+            error_reason: `str`, optionally sets the "reason" field in the error class (default: None)
+        """
+        # Check parameter validity
+        if not issubclass(error_class, ValidationError):
+            raise TypeError('Error class must be a subclass of ValidationError.')
+
+        # Save parameters
+        self.allow_none = allow_none
+        self.error_class = error_class
+        self.error_code = error_code
+        self.error_reason = error_reason
+
+    def validate(self, input_data: Any) -> None:
+        """
+        Validate input data. In this case, reject any value (except for `None` if allow_none is set).
+        """
+        # Accept None (if allowed)
+        if self.allow_none and input_data is None:
+            return None
+
+        # Reject any input
+        raise self.error_class(code=self.error_code, reason=self.error_reason)

--- a/src/validataclass/validators/reject_validator.py
+++ b/src/validataclass/validators/reject_validator.py
@@ -16,7 +16,7 @@ __all__ = [
 
 class RejectValidator(Validator):
     """
-    Meta validator that rejects any input data with a validation error.
+    Special validator that rejects any input data with a validation error.
 
     This validator can be used for example in dataclasses to define a field that may never be set, or to override an
     existing field in a subclassed dataclass that may not be set in this subclass. Keep in mind that in a dataclass

--- a/tests/validators/noneable_test.py
+++ b/tests/validators/noneable_test.py
@@ -14,7 +14,7 @@ from validataclass.validators import Noneable, DecimalValidator, IntegerValidato
 
 class NoneableTest:
     """
-    Unit tests for the Noneable meta validator.
+    Unit tests for the Noneable wrapper validator.
     """
 
     @staticmethod

--- a/tests/validators/reject_validator_test.py
+++ b/tests/validators/reject_validator_test.py
@@ -1,0 +1,106 @@
+"""
+validataclass
+Copyright (c) 2022, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+import pytest
+
+from tests.test_utils import UNSET_PARAMETER
+from validataclass.exceptions import ValidationError, FieldNotAllowedError
+from validataclass.validators import RejectValidator
+
+
+class UnitTestValidationError(ValidationError):
+    """
+    Example exception to use as a custom error class in RejectValidator tests.
+    """
+    code = 'unit_test_error'
+
+
+class RejectValidatorTest:
+    """
+    Unit tests for the RejectValidator.
+    """
+
+    # Tests with any non-None value
+
+    @staticmethod
+    @pytest.mark.parametrize('allow_none', [UNSET_PARAMETER, False, True])
+    @pytest.mark.parametrize('input_data', [False, True, '', 'banana', 0, 123, []])
+    def test_reject_anything_except_none(allow_none, input_data):
+        """ Test that RejectValidator rejects anything (except None) with a FieldNotAllowedError. """
+        validator = RejectValidator() if allow_none is UNSET_PARAMETER \
+            else RejectValidator(allow_none=allow_none)
+
+        with pytest.raises(FieldNotAllowedError) as exc_info:
+            validator.validate(input_data)
+        assert exc_info.value.to_dict() == {'code': 'field_not_allowed'}
+
+    # Tests with None as input
+
+    @staticmethod
+    @pytest.mark.parametrize('allow_none', [UNSET_PARAMETER, False])
+    def test_reject_none(allow_none):
+        """ Test that RejectValidator rejects None if allow_none is not True. """
+        validator = RejectValidator() if allow_none is UNSET_PARAMETER \
+            else RejectValidator(allow_none=allow_none)
+
+        with pytest.raises(FieldNotAllowedError) as exc_info:
+            validator.validate(None)
+        assert exc_info.value.to_dict() == {'code': 'field_not_allowed'}
+
+    @staticmethod
+    def test_allow_none():
+        """ Test that RejectValidator allows None if allow_none is True. """
+        validator = RejectValidator(allow_none=True)
+        assert validator.validate(None) is None
+
+    # Tests with custom errors
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'error_class, error_code, error_reason, expected_error_code',
+        [
+            # Defaults
+            (UNSET_PARAMETER, None, None, 'field_not_allowed'),
+
+            # Default error class with custom error code and/or reason
+            (UNSET_PARAMETER, None, 'This is a unit test.', 'field_not_allowed'),
+            (UNSET_PARAMETER, 'custom_error_code', None, 'custom_error_code'),
+            (UNSET_PARAMETER, 'custom_error_code', 'This is a unit test.', 'custom_error_code'),
+
+            # Custom error class with default code and no reason
+            (UnitTestValidationError, None, None, 'unit_test_error'),
+
+            # Custom error class with custom error code and/or reason
+            (UnitTestValidationError, None, 'This is a unit test.', 'unit_test_error'),
+            (UnitTestValidationError, 'custom_error_code', None, 'custom_error_code'),
+            (UnitTestValidationError, 'custom_error_code', 'This is a unit test.', 'custom_error_code'),
+        ]
+    )
+    @pytest.mark.parametrize('input_data', [None, 0, 'banana'])
+    def test_custom_errors(error_class, error_code, error_reason, expected_error_code, input_data):
+        """ Test RejectValidator with various custom error settings. """
+        # Build expectations
+        expected_error_class = error_class if error_class is not UNSET_PARAMETER else FieldNotAllowedError
+        expected_error_dict = {'code': expected_error_code}
+        if error_reason is not None:
+            expected_error_dict['reason'] = error_reason
+
+        # Create validator
+        validator = RejectValidator(error_code=error_code, error_reason=error_reason) if error_class is UNSET_PARAMETER \
+            else RejectValidator(error_class=error_class, error_code=error_code, error_reason=error_reason)
+
+        # Test validator
+        with pytest.raises(ValidationError) as exc_info:
+            validator.validate(input_data)
+
+        assert type(exc_info.value) is expected_error_class
+        assert exc_info.value.to_dict() == expected_error_dict
+
+    @staticmethod
+    def test_custom_error_class_invalid_type():
+        """ Test that RejectValidator raises an error on construction if the error class is not a ValidatonError subclass. """
+        with pytest.raises(TypeError, match='Error class must be a subclass of ValidationError'):
+            RejectValidator(error_class=Exception)  # noqa


### PR DESCRIPTION
This PR implements the special `RejectValidator` that rejects any input (see #20).

I also decided to drop the term "meta validators" and just call them special validators (or in wrapper validator in case of `Noneable`), since the word "meta" doesn't really fit here.