### PR TITLE
New validator: NoneToUnsetValue

### DIFF
--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -54,6 +54,7 @@ A much more useful distinction is to categorize the validators according to thei
 
 - Special validators:
   - `Noneable`: Wraps another validator but allows the input to be `None`
+  - `NoneToUnsetValue`: Like `Noneable`, but converts `None` to `UnsetValue`
   - `AnythingValidator`: Accepts any input without validation (optionally with type restrictions)
   - `RejectValidator`: Rejects any input with a validation error (except for `None` if allowed)
 
@@ -990,6 +991,29 @@ validator = Noneable(StringValidator(), default='no value given!')
 validator.validate('banana')  # will return the string 'banana'
 validator.validate('')        # will return the string ''
 validator.validate(None)      # will return the string 'no value given!'
+```
+
+
+### NoneToUnsetValue
+
+The `NoneToUnsetValue` validator is a variation of the `Noneable` validator. It is equivalent to
+`Noneable(validator, default=UnsetValue)`.
+
+In other words, if the input value is `None`, this validator returns the special value `UnsetValue`. In all other cases,
+the input is validated using the wrapped validator.
+
+**Note:** The meaning of `UnsetValue` is explained later in the chapter about [dataclasses](05-dataclasses.md).
+
+**Examples:**
+
+```python
+from validataclass.validators import NoneToUnsetValue, StringValidator
+
+# Accepts all strings allowed by the StringValidator, and None, which is converted to UnsetValue
+validator = NoneToUnsetValue(StringValidator())
+validator.validate('banana')  # will return 'banana'
+validator.validate('')        # will return '' (empty string)
+validator.validate(None)      # will return UnsetValue
 ```
 
 

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -36,11 +36,13 @@ class UnsetValueType:
     def __bool__(self):
         return False
 
+    def __eq__(self, other):
+        return other is self
+
 
 # Create sentinel object and redefine __new__ so that the object cannot be cloned
 UnsetValue = UnsetValueType()
 UnsetValueType.__new__ = lambda cls: UnsetValue
-
 
 # Type alias OptionalUnset[T] for fields with DefaultUnset (similar to Optional[T] but using UnsetValueType instead of NoneType)
 T = TypeVar('T')

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -15,6 +15,7 @@ from .string_validator import StringValidator
 
 # Special validators
 from .noneable import Noneable
+from .none_to_unset_value import NoneToUnsetValue
 from .anything_validator import AnythingValidator
 from .reject_validator import RejectValidator
 

--- a/src/validataclass/validators/none_to_unset_value.py
+++ b/src/validataclass/validators/none_to_unset_value.py
@@ -1,0 +1,45 @@
+"""
+validataclass
+Copyright (c) 2021, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from validataclass.helpers import UnsetValue
+from .noneable import Noneable
+from .validator import Validator
+
+__all__ = [
+    'NoneToUnsetValue',
+]
+
+
+class NoneToUnsetValue(Noneable):
+    """
+    Shortcut variation of the `Noneable` wrapper, using `UnsetValue` as the default value.
+
+    This is a special validator that wraps another validator, but allows `None` as the input value. If the input is
+    `None`, the validator returns the special value `UnsetValue`. Otherwise the wrapped validator is used to validate
+    the input.
+
+    This validator is equivalent to `Noneable(validator, default=UnsetValue)`.
+
+    Examples:
+
+    ```
+    # Accepts strings and None. Instead of None, UnsetValue is returned (e.g. "foo" -> "foo", None -> UnsetValue)
+    NoneToUnsetValue(StringValidator())
+
+    # Equivalent to the following:
+    Noneable(StringValidator(), default=UnsetValue)
+    ```
+
+    Valid input: `None` or any data accepted by the wrapped validator
+    Output: `UnsetValue` or the output of the wrapped validator
+    """
+
+    def __init__(self, validator: Validator):
+        """
+        Create a NoneToUnsetValue wrapper for a specified validator.
+        """
+        # Initialize base Noneable wrapper
+        super().__init__(validator, default=UnsetValue)

--- a/src/validataclass/validators/noneable.py
+++ b/src/validataclass/validators/noneable.py
@@ -35,6 +35,8 @@ class Noneable(Validator):
     Noneable(StringValidator(), default='no value given!')
     ```
 
+    See also: `NoneToUnsetValue`
+
     Valid input: `None` or any data accepted by the wrapped validator
     Output: `None` (or default value specified in constructor) or the output of the wrapped validator
     """

--- a/tests/helpers/dataclass_mixins_test.py
+++ b/tests/helpers/dataclass_mixins_test.py
@@ -100,12 +100,9 @@ class ValidataclassMixinTest:
     @staticmethod
     def test_create_with_defaults_invalid_required_fields():
         """ Tests the create_with_defaults() class method missing required fields. """
-        with pytest.raises(TypeError) as exception_info:
+        # The exact exception message changed between Python versions 3.9 and 3.10
+        with pytest.raises(TypeError, match="missing 1 required positional argument: 'foo'"):
             UnitTestDataclass.create_with_defaults()
-
-        # The exact exception message changed between Python versions 3.9 (first variant) and 3.10 (second variant)
-        assert str(exception_info.value) == "__init__() missing 1 required positional argument: 'foo'" \
-            or str(exception_info.value) == "UnitTestDataclass.__init__() missing 1 required positional argument: 'foo'"
 
     @staticmethod
     def test_create_with_defaults_on_subclass():

--- a/tests/helpers/unset_value_test.py
+++ b/tests/helpers/unset_value_test.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from copy import copy
 
+import pytest
+
 from validataclass.helpers import UnsetValue, UnsetValueType
 
 
@@ -30,3 +32,17 @@ class UnsetValueTest:
 
         # Test that calling the UnsetValue returns the UnsetValue itself
         assert UnsetValue() is UnsetValue
+
+    @staticmethod
+    def test_unset_value_equal_to_itself():
+        """ Test that UnsetValue is equal to itself. """
+        assert UnsetValue == UnsetValue
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'other_value', [None, False, True, object(), 0, '', 'UnsetValue', '<UnsetValue>', (UnsetValue,), [UnsetValue]]
+    )
+    def test_unset_value_not_equal(other_value):
+        """ Test that nothing is equal to UnsetValue (except itself). """
+        assert other_value != UnsetValue
+        assert UnsetValue != other_value

--- a/tests/validators/none_to_unset_value_test.py
+++ b/tests/validators/none_to_unset_value_test.py
@@ -1,0 +1,48 @@
+"""
+validataclass
+Copyright (c) 2021, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from validataclass.exceptions import ValidationError
+from validataclass.helpers import UnsetValue
+from validataclass.validators import NoneToUnsetValue, DecimalValidator
+
+
+class NoneToUnsetValueTest:
+    """
+    Unit tests for the NoneToUnsetValue wrapper.
+    """
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data, expected_result',
+        [
+            (None, UnsetValue),
+            ('12.34', Decimal('12.34')),
+        ]
+    )
+    def test_valid(input_data, expected_result):
+        """ Test NoneToUnsetValue with different valid input (None and non-None). """
+        validator = NoneToUnsetValue(DecimalValidator())
+        result = validator.validate(input_data)
+
+        assert type(result) == type(expected_result)
+        assert result == expected_result
+
+    @staticmethod
+    def test_invalid_type():
+        """ Test that NoneToUnsetValue correctly re-raises or ignores validation errors from the wrapped validator. """
+        validator = NoneToUnsetValue(DecimalValidator())
+
+        with pytest.raises(ValidationError) as exception_info:
+            validator.validate(123)
+
+        assert exception_info.value.to_dict() == {
+            'code': 'invalid_type',
+            'expected_types': ['none', 'str'],
+        }

--- a/tests/validators/noneable_test.py
+++ b/tests/validators/noneable_test.py
@@ -98,6 +98,5 @@ class NoneableTest:
     )
     def test_invalid_validator_type(validator):
         """ Test that Noneable raises an exception on construction if the wrapped validator has the wrong type. """
-        with pytest.raises(TypeError) as exception_info:
+        with pytest.raises(TypeError, match='Noneable requires a Validator instance'):
             Noneable(validator)  # noqa
-        assert str(exception_info.value) == 'Noneable requires a Validator instance.'

--- a/tests/validators/regex_validator_test.py
+++ b/tests/validators/regex_validator_test.py
@@ -157,9 +157,8 @@ class RegexValidatorTest:
     @staticmethod
     def test_invalid_regex_pattern():
         """ Check that RegexValidator raises an exception for invalid regex patterns. """
-        with pytest.raises(re.error) as exception_info:
+        with pytest.raises(re.error, match='unterminated character set at position 0'):
             RegexValidator('[')
-        assert str(exception_info.value) == 'unterminated character set at position 0'
 
     # Test RegexValidator with custom error classes and/or error codes
 
@@ -194,15 +193,14 @@ class RegexValidatorTest:
         with pytest.raises(ValidationError) as exception_info:
             validator.validate('x')
 
-        assert type(exception_info.value) == expected_error_class
+        assert type(exception_info.value) is expected_error_class
         assert exception_info.value.to_dict() == {'code': expected_error_code}
 
     @staticmethod
     def test_custom_error_class_invalid_type():
         """ Test that RegexValidator raises an error on construction if the custom error class is not a ValidatonError subclass. """
-        with pytest.raises(TypeError) as exception_info:
+        with pytest.raises(TypeError, match='Custom error class must be a subclass of ValidationError'):
             RegexValidator('[0-9]', custom_error_class=Exception)  # noqa
-        assert str(exception_info.value) == 'Custom error class must be a subclass of ValidationError.'
 
     # Tests with length requirements
 


### PR DESCRIPTION
This PR adds a new special validator `NoneToUnsetValue`, which is just a shortcut for `Noneable(validator, default=UnsetValue)`.

There also is a minor addition in the `UnsetValue` object (it explicitly implements `__eq__` now and has unit tests for that).