### PR TITLE
DataclassValidator: Don't catch non-ValidationError exceptions

### DIFF
--- a/src/validataclass/exceptions/__init__.py
+++ b/src/validataclass/exceptions/__init__.py
@@ -8,13 +8,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from .meta_exceptions import InvalidValidatorOptionException, DataclassValidatorFieldException
 
 # Base and common validation error exceptions (base class ValidationError)
-from .common_exceptions import (
-    ValidationError,
-    RequiredValueError,
-    FieldNotAllowedError,
-    InternalValidationError,
-    InvalidTypeError,
-)
+from .common_exceptions import ValidationError, RequiredValueError, FieldNotAllowedError, InvalidTypeError
 
 # More specific validation errors
 from .dataclass_exceptions import DataclassPostValidationError

--- a/src/validataclass/exceptions/common_exceptions.py
+++ b/src/validataclass/exceptions/common_exceptions.py
@@ -11,7 +11,6 @@ __all__ = [
     'RequiredValueError',
     'FieldNotAllowedError',
     'InvalidTypeError',
-    'InternalValidationError',
 ]
 
 
@@ -130,25 +129,4 @@ class InvalidTypeError(ValidationError):
             base_dict.update({'expected_type': self.expected_types[0]})
         else:
             base_dict.update({'expected_types': self.expected_types})
-        return base_dict
-
-
-class InternalValidationError(ValidationError):
-    """
-    Validation error raised when an unhandled exception (that is not a `ValidationError` subclass) occurs, e.g. in post validation.
-
-    The unhandled exception can be wrapped inside the 'internal_error' argument, which will NOT be included in `to_dict()` but will
-    be accessible via `error.internal_error` or `repr(error)` for debugging purposes.
-    """
-    code = 'internal_error'
-    internal_error: Optional[Exception] = None
-
-    def __init__(self, *, internal_error: Optional[Exception] = None, **kwargs):
-        super().__init__(**kwargs)
-        self.internal_error = internal_error
-
-    def _get_repr_dict(self) -> Dict[str, str]:
-        base_dict = super()._get_repr_dict()
-        if self.internal_error is not None:
-            base_dict['internal_error'] = repr(self.internal_error)
         return base_dict

--- a/src/validataclass/validators/dataclass_validator.py
+++ b/src/validataclass/validators/dataclass_validator.py
@@ -7,10 +7,10 @@ Use of this source code is governed by an MIT-style license that can be found in
 import dataclasses
 from typing import Any, Optional, TypeVar, Generic, Dict
 
-from . import Validator, DictValidator
-from validataclass.exceptions import InvalidValidatorOptionException, DataclassValidatorFieldException, ValidationError, \
-    DataclassPostValidationError, InternalValidationError
+from validataclass.exceptions import ValidationError, DataclassValidatorFieldException, DataclassPostValidationError, \
+    InvalidValidatorOptionException
 from validataclass.helpers import Default, NoDefault
+from . import Validator, DictValidator
 
 __all__ = [
     'DataclassValidator',
@@ -173,10 +173,7 @@ class DataclassValidator(DictValidator, Generic[T_Dataclass]):
         except ValidationError as error:
             # Wrap validation error in a DataclassPostValidationError
             raise DataclassPostValidationError(error=error)
-        except Exception as error:
-            # Wrap unknown exception in an 'internal_error' (the exception will not be included in to_dict() but accessible for debugging)
-            internal_error = InternalValidationError(internal_error=error)
-            raise DataclassPostValidationError(error=internal_error)
+        # Ignore all non-ValidationError exceptions (these are either errors in the code or should be handled properly by the user)
 
     # noinspection PyMethodMayBeStatic
     def post_validate(self, validated_object: T_Dataclass) -> T_Dataclass:

--- a/tests/exceptions/common_exceptions_test.py
+++ b/tests/exceptions/common_exceptions_test.py
@@ -6,7 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 import pytest
 
-from validataclass.exceptions import ValidationError, InvalidTypeError, InternalValidationError
+from validataclass.exceptions import ValidationError, InvalidTypeError
 
 
 class ValidationErrorTest:
@@ -130,32 +130,3 @@ class InvalidTypeErrorTest:
         # Check error after adding types
         assert repr(error) == "InvalidTypeError(code='invalid_type', expected_types=['banana', 'float', 'int'])"
         assert error.to_dict() == {'code': 'invalid_type', 'expected_types': ['banana', 'float', 'int']}
-
-
-class InternalValidationErrorTest:
-    """
-    Tests for the InternalValidationError exception class.
-    This exception should look like a regular exception when using to_dict(), but repr() should contain the internal exception.
-    """
-
-    @staticmethod
-    def test_internal_validation_error_without_exception():
-        """ Tests InternalValidationError with some internal exception. """
-        error = InternalValidationError()
-
-        # No internal_error in neither representation
-        assert repr(error) == "InternalValidationError(code='internal_error')"
-        assert error.to_dict() == {'code': 'internal_error'}
-
-    @staticmethod
-    def test_internal_validation_error_with_exception():
-        """ Tests InternalValidationError with some internal exception. """
-        internal_error = ValueError('banana.')
-        error = InternalValidationError(internal_error=internal_error)
-
-        # Check that exception contains the internal error
-        assert error.internal_error is internal_error
-        assert repr(error) == "InternalValidationError(code='internal_error', internal_error=ValueError('banana.'))"
-
-        # The to_dict() representation (user-facing) should not contain the internal exception though
-        assert error.to_dict() == {'code': 'internal_error'}

--- a/tests/validators/dataclass_validator_test.py
+++ b/tests/validators/dataclass_validator_test.py
@@ -10,7 +10,7 @@ from typing import Optional
 import pytest
 
 from validataclass.exceptions import ValidationError, RequiredValueError, DictFieldsValidationError, DataclassPostValidationError, \
-    InternalValidationError, InvalidValidatorOptionException, DataclassValidatorFieldException
+    InvalidValidatorOptionException, DataclassValidatorFieldException
 from validataclass.helpers import validataclass, validataclass_field, Default, DefaultFactory, DefaultUnset, UnsetValue, OptionalUnset
 from validataclass.validators import DataclassValidator, DecimalValidator, IntegerValidator, StringValidator
 
@@ -314,21 +314,12 @@ class DataclassValidatorTest:
 
         validator: DataclassValidator[PostInitDataclass] = DataclassValidator(PostInitDataclass)
 
-        with pytest.raises(DataclassPostValidationError) as exception_info:
+        with pytest.raises(ZeroDivisionError):
             # Let's cause a divide-by-zero error!
             validator.validate({
                 'a': 1,
                 'b': 0,
             })
-
-        assert exception_info.value.to_dict() == {
-            'code': 'post_validation_errors',
-            'error': {
-                'code': 'internal_error',
-            },
-        }
-        assert type(exception_info.value.wrapped_error) is InternalValidationError
-        assert type(getattr(exception_info.value.wrapped_error, 'internal_error')) is ZeroDivisionError
 
     # Tests for subclassed DataclassValidators (with post_validate() method)
 


### PR DESCRIPTION
This PR changes the DataclassValidator to catch ONLY `ValidationError` exceptions. Other exceptions are ignored, so they bubble up to the application. See #58.

This PR also **removes** the `InternalValidationError` exception class, since now it is not needed anymore.

These technically are breaking changes, but I doubt that any code depended on either the handling of non-ValidationError exceptions in the DataclassValidator, nor used the InternalValidationError anywhere.