### PR TITLE
Fix Default objects with mutable values (e.g. lists)

### DIFF
--- a/src/validataclass/dataclasses/validataclass_field.py
+++ b/src/validataclass/dataclasses/validataclass_field.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, Optional, NoReturn
 
 from validataclass.validators import Validator
-from .defaults import Default, NoDefault, DefaultFactory, DefaultUnset
+from .defaults import Default, NoDefault
 
 __all__ = [
     'validataclass_field',
@@ -64,14 +64,11 @@ def validataclass_field(
         # Add default values to metadata
         metadata['validator_default'] = default
 
-        # Set regular dataclass default (depending on the type of default)
-        if type(default) is Default or default is DefaultUnset:
-            kwargs['default'] = default.get_value()
-        elif type(default) is DefaultFactory:
-            kwargs['default_factory'] = default.factory
-        else:
-            # Fallback to a lambda
+        # Set regular dataclass default or default_factory
+        if default.needs_factory():
             kwargs['default_factory'] = lambda: default.get_value()
+        else:
+            kwargs['default'] = default.get_value()
 
     # Compatibility for Python 3.9 and older: Use a workaround to allow required and optional fields to be defined in
     # any order. (In Python 3.10 the kw_only=True option for dataclasses is introduced, which can be used instead.)

--- a/src/validataclass/validators/dict_validator.py
+++ b/src/validataclass/validators/dict_validator.py
@@ -79,7 +79,7 @@ class DictValidator(Validator):
         """
         Creates a DictValidator.
 
-        At least one of the parameters `field_validators` and `default_validator` is required (both can be conmbined).
+        At least one of the parameters `field_validators` and `default_validator` is required (both can be combined).
         The parameters `required_fields` and `optional_fields` are mutually exclusive (cannot be combined).
         See class documentation (above) for more information.
 

--- a/tests/dataclasses/_helpers.py
+++ b/tests/dataclasses/_helpers.py
@@ -20,7 +20,8 @@ def assert_field_default(field: dataclasses.Field, default_value: Any):
     Asserts that a given (vali-)dataclass field has a specified default value.
     """
     # Check regular dataclass defaults
-    assert field.default == default_value
+    assert (field.default == default_value and field.default_factory is dataclasses.MISSING) or \
+           (field.default is dataclasses.MISSING and field.default_factory() == default_value)
 
     # Check defaults in dataclass metadata
     metadata_default = field.metadata.get('validator_default')

--- a/tests/dataclasses/defaults_test.py
+++ b/tests/dataclasses/defaults_test.py
@@ -16,26 +16,39 @@ class DefaultTest:
     """ Tests for the base Default class. """
 
     @staticmethod
-    def test_default_none():
-        """ Test Default object with None value. """
-        default = Default(None)
-        assert repr(default) == 'Default(None)'
-        assert default.get_value() is None
+    @pytest.mark.parametrize(
+        'value, expected_repr',
+        [
+            (None, 'Default(None)'),
+            (True, 'Default(True)'),
+            (False, 'Default(False)'),
+            (UnsetValue, 'Default(UnsetValue)'),
+            (42, 'Default(42)'),
+            (1.234, 'Default(1.234)'),
+            ('banana', "Default('banana')"),
+        ]
+    )
+    def test_default_immutable_values(value, expected_repr):
+        """ Test Default object with different immutable values. """
+        default = Default(value)
 
-    @staticmethod
-    def test_default_integer():
-        """ Test Default object with some integer value. """
-        default = Default(42)
-        assert repr(default) == 'Default(42)'
-        assert default.get_value() == 42
+        # Check string representation and value
+        assert repr(default) == expected_repr
+        assert default.get_value() == value
+
+        # Immutable values do not need a factory
+        assert not default.needs_factory()
 
     @staticmethod
     def test_default_list_deepcopied():
         """ Test Default object with a list, make sure that it is deepcopied. """
         default_list = []
         default = Default(default_list)
+
+        # Check string representation and value
         assert repr(default) == 'Default([])'
         assert default.get_value() == []
+        assert default.needs_factory()
 
         # Make sure list was copied by checking if the Default object value is modified when modifying the original list
         default_list.append(3)
@@ -45,9 +58,34 @@ class DefaultTest:
         # Make sure list is copied every time the default value is used
         value1 = default.get_value()
         value2 = default.get_value()
-        value1.append(3)
-        assert value1 == [3]
-        assert value2 == []
+        assert value1 is not value2
+
+    @staticmethod
+    def test_default_equality():
+        """ Test equality and non-equality of Default objects. """
+        assert Default(None) == Default(None)
+        assert Default(UnsetValue) == Default(UnsetValue)
+        assert Default(0) == Default(0)
+        assert Default('') == Default('')
+        assert Default([]) == Default([])
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'first, second',
+        [
+            (Default(None), None),
+            (Default(None), Default(0)),
+            (Default(None), Default(UnsetValue)),
+            (Default(0), 0),
+            (Default(0), Default('')),
+            (Default([]), Default([0])),
+            (Default([]), Default({})),
+        ]
+    )
+    def test_default_non_equality(first, second):
+        """ Test non-equality between Default and other objects. """
+        assert first != second
+        assert second != first
 
 
 class DefaultFactoryTest:
@@ -63,6 +101,9 @@ class DefaultFactoryTest:
     def test_default_factory_list():
         """ Test DefaultFactory with `list` as default generator. """
         default_factory = DefaultFactory(list)
+        assert default_factory.needs_factory()
+
+        # Generate values and test that they are not the same objects
         value1 = default_factory.get_value()
         value2 = default_factory.get_value()
         assert value1 == [] and value2 == []
@@ -73,6 +114,9 @@ class DefaultFactoryTest:
         """ Test DefaultFactory with a lambda function. """
         # This lambda function will create a new list and return its object ID, which will be a different one each time.
         default_factory = DefaultFactory(lambda: id(list()))
+        assert default_factory.needs_factory()
+
+        # Generate values and test that they are different from each other
         value1 = default_factory.get_value()
         value2 = default_factory.get_value()
         assert type(value1) is int and type(value2) is int
@@ -89,9 +133,39 @@ class DefaultFactoryTest:
             return current
 
         default_factory = DefaultFactory(counter)
+        assert default_factory.needs_factory()
+
+        # Generate values and check that they are counting upwards
         assert default_factory.get_value() == 1
         assert default_factory.get_value() == 2
         assert default_factory.get_value() == 3
+
+    @staticmethod
+    def test_default_factory_equality():
+        """ Test equality and non-equality of DefaultFactory objects. """
+
+        def example_fun():
+            return 42
+
+        assert DefaultFactory(list) == DefaultFactory(list)
+        assert DefaultFactory(example_fun) == DefaultFactory(example_fun)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'first, second',
+        [
+            (DefaultFactory(list), list),
+            (DefaultFactory(list), DefaultFactory(dict)),
+            (DefaultFactory(lambda: 1), DefaultFactory(lambda: 2)),
+            (DefaultFactory(lambda: 0), 0),
+            (DefaultFactory(lambda: 0), Default(0)),
+            (DefaultFactory(lambda: 0), DefaultUnset),
+        ]
+    )
+    def test_default_factory_non_equality(first, second):
+        """ Test non-equality between DefaultFactory and other objects. """
+        assert first != second
+        assert second != first
 
 
 class DefaultUnsetTest:
@@ -103,6 +177,7 @@ class DefaultUnsetTest:
         default = DefaultUnset
         assert repr(default) == 'DefaultUnset'
         assert default.get_value() is UnsetValue
+        assert not default.needs_factory()
 
     @staticmethod
     def test_default_unset_is_unique():
@@ -110,6 +185,23 @@ class DefaultUnsetTest:
         default1 = DefaultUnset
         default2 = copy(DefaultUnset)
         assert default1 is default2 is DefaultUnset
+
+    @staticmethod
+    def test_default_unset_equality():
+        """ Test equality between DefaultUnset and Default(UnsetValue) objects. """
+        assert DefaultUnset == DefaultUnset
+        assert DefaultUnset == Default(UnsetValue)
+        assert Default(UnsetValue) == DefaultUnset
+
+        assert DefaultUnset != Default(None)
+        assert Default(None) != DefaultUnset
+
+    @staticmethod
+    @pytest.mark.parametrize('other', [UnsetValue, None, Default(None), Default(0), DefaultFactory(lambda: None)])
+    def test_default_unset_non_equality(other):
+        """ Test non-equality between DefaultUnset and other objects. """
+        assert DefaultUnset != other
+        assert other != DefaultUnset
 
     @staticmethod
     def test_default_unset_call():
@@ -136,7 +228,15 @@ class NoDefaultTest:
         """ Test that NoDefault cannot be cloned. """
         default1 = NoDefault
         default2 = copy(NoDefault)
+        assert default1 == default2
         assert default1 is default2 is NoDefault
+
+    @staticmethod
+    @pytest.mark.parametrize('other', [None, Default(None), UnsetValue, DefaultUnset, DefaultFactory(lambda: None)])
+    def test_no_default_non_equality(other):
+        """ Test non-equality between NoDefault and other objects. """
+        assert NoDefault != other
+        assert other != NoDefault
 
     @staticmethod
     def test_no_default_call():


### PR DESCRIPTION
This PR fixes a bug where `Default` objects with mutable values, for example lists (`Default([])`), would cause errors when defining validataclasses.

This bug was introduced in the latest release (0.6.0) due to the reimplementation of Defaults.

The PR changes how `default` and `default_factory` are set in validataclass fields. The `Default` class and subclasses have also been a bit extended and now feature a `needs_factory()` method (which should return True if the Default represents any value that changes whenever the default value is retrieved, e.g. a list would always be deepcopied). Also, `Default` implements `__eq__` now.

I also added a few tests that would have detected this bug before the release.