### PR TITLE
Fix overriding of existing field properties in validataclasses with multiple inheritance

### DIFF
--- a/tests/dataclasses/validataclass_test.py
+++ b/tests/dataclasses/validataclass_test.py
@@ -362,7 +362,7 @@ class ValidatorDataclassTest:
         @validataclass
         class BaseA:
             field_a: int = IntegerValidator()
-            field_both: int = IntegerValidator(), Default(1)
+            field_both: int = (IntegerValidator(), Default(1))
 
         @validataclass
         class BaseB:

--- a/tests/dataclasses/validataclass_test.py
+++ b/tests/dataclasses/validataclass_test.py
@@ -355,6 +355,42 @@ class ValidatorDataclassTest:
         assert fields['non_init'].default == 1
         assert 'validator' not in fields['non_init'].metadata
 
+    @staticmethod
+    def test_validataclass_multiple_inheritance():
+        """ Test that the @validataclass decorator handles multiple inheritance correctly. """
+
+        @validataclass
+        class BaseA:
+            field_a: int = IntegerValidator()
+            field_both: int = IntegerValidator(), Default(1)
+
+        @validataclass
+        class BaseB:
+            field_b: str = StringValidator()
+            field_both: str = StringValidator()
+
+        @validataclass
+        class SubClass(BaseB, BaseA):
+            # Override the defaults to test that the decorator recognizes all fields of both base classes.
+            # If it does not, a "no validator for field X" error would be raised.
+            field_a: int = Default(42)
+            field_b: Optional[str] = Default(None)
+
+        # Get fields from dataclass
+        fields = get_dataclass_fields(SubClass)
+
+        # Check validators and defaults of overridden fields
+        assert isinstance(fields['field_a'].metadata.get('validator'), IntegerValidator)
+        assert isinstance(fields['field_b'].metadata.get('validator'), StringValidator)
+        assert fields['field_a'].metadata.get('validator_default') == Default(42)
+        assert fields['field_b'].metadata.get('validator_default') == Default(None)
+
+        # For fields defined in both base classes, BaseB should take precedence over BaseA (MRO: SubClass, BaseB, BaseA, object).
+        # Since BaseB does NOT inherit from BaseA, there should NOT be partial overrides in the field, i.e. field_both in
+        # SubClass does not have a default, since the field has no default in BaseB.
+        assert isinstance((fields['field_both'].metadata.get('validator')), StringValidator)
+        assert fields['field_both'].metadata.get('validator_default') is None
+
     # Error cases
 
     @staticmethod


### PR DESCRIPTION
This PR fixes a bug in the validataclass decorator related to multiple inheritance.

The following code was not working:

```
@validataclass
class BaseA:
    field_a: int = IntegerValidator()

@validataclass
class BaseB:
    field_b: int = IntegerValidator()

@validataclass
class SubClass(BaseB, BaseA):
    field_a: int = Default(42)  # raises: Dataclass field "field_a" must specify a Validator.
    field_b: int = Default(42)  # this works fine
```

So, when overriding a field from a base class, the existing properties are only recognized if the base class has the highest MRO (in this case: only fields from BaseB can be overridden correctly).

With this bugfix, existing fields from *all* base classes will be considered when constructing the dataclass fields.