### PR TITLE
Add helper function unset_to_none()

### DIFF
--- a/src/validataclass/helpers/__init__.py
+++ b/src/validataclass/helpers/__init__.py
@@ -8,12 +8,12 @@ import importlib
 import warnings
 
 from .datetime_range import BaseDateTimeRange, DateTimeRange, DateTimeOffsetRange
-from .unset_value import UnsetValue, UnsetValueType, OptionalUnset, OptionalUnsetNone
+from .unset_value import UnsetValue, UnsetValueType, OptionalUnset, OptionalUnsetNone, unset_to_none
 
 # Defining __all__ is necessary here because of the definition of __getattr__() below.
 __all__ = [
     'BaseDateTimeRange', 'DateTimeRange', 'DateTimeOffsetRange',
-    'UnsetValue', 'UnsetValueType', 'OptionalUnset', 'OptionalUnsetNone',
+    'UnsetValue', 'UnsetValueType', 'OptionalUnset', 'OptionalUnsetNone', 'unset_to_none',
 ]
 
 

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -11,7 +11,10 @@ __all__ = [
     'UnsetValueType',
     'OptionalUnset',
     'OptionalUnsetNone',
+    'unset_to_none',
 ]
+
+T = TypeVar('T')
 
 
 # Class to create the UnsetValue sentinel object
@@ -45,8 +48,17 @@ UnsetValue = UnsetValueType()
 UnsetValueType.__new__ = lambda cls: UnsetValue
 
 # Type alias OptionalUnset[T] for fields with DefaultUnset (similar to Optional[T] but using UnsetValueType instead of NoneType)
-T = TypeVar('T')
 OptionalUnset = Union[T, UnsetValueType]
 
 # Type alias OptionalUnsetNone[T] for fields that can be None or UnsetValue (equivalent to OptionalUnset[Optional[T]])
 OptionalUnsetNone = OptionalUnset[Optional[T]]
+
+
+# Small helper function for easier conversion of UnsetValue to None
+def unset_to_none(value: OptionalUnset[T]) -> Optional[T]:
+    """
+    Converts `UnsetValue` to `None`.
+
+    Returns `None` if the given value is `UnsetValue`, otherwise the value is returned unmodified.
+    """
+    return None if value is UnsetValue else value

--- a/tests/helpers/unset_value_test.py
+++ b/tests/helpers/unset_value_test.py
@@ -8,7 +8,7 @@ from copy import copy
 
 import pytest
 
-from validataclass.helpers import UnsetValue, UnsetValueType
+from validataclass.helpers import UnsetValue, UnsetValueType, unset_to_none
 
 
 class UnsetValueTest:
@@ -46,3 +46,16 @@ class UnsetValueTest:
         """ Test that nothing is equal to UnsetValue (except itself). """
         assert other_value != UnsetValue
         assert UnsetValue != other_value
+
+
+def test_unset_to_none_with_unset_value():
+    """ Test the unset_to_none() helper function with UnsetValue as input. """
+    assert unset_to_none(UnsetValue) is None
+
+
+@pytest.mark.parametrize(
+    'value', [None, '', 'banana', 0, 42, [], {}]
+)
+def test_unset_to_none_with_any_value(value):
+    """ Test the unset_to_none() helper function with input that is not UnsetValue. """
+    assert unset_to_none(value) is value


### PR DESCRIPTION
This PR adds a small helper function `unset_to_none()` (from `validataclass.helpers`).

The function takes any value as input and returns `None` if the input is `UnsetValue`, or the unmodified value in any other case.