### PR TITLE
Context-sensitive validation / __post_validate__()

### DIFF
--- a/src/validataclass/validators/dataclass_validator.py
+++ b/src/validataclass/validators/dataclass_validator.py
@@ -144,12 +144,12 @@ class DataclassValidator(DictValidator, Generic[T_Dataclass]):
             raise DataclassValidatorFieldException(f'Default specified for dataclass field "{field.name}" is not of type "Default".')
         return default
 
-    def validate(self, input_data: Any) -> T_Dataclass:
+    def validate(self, input_data: Any, **kwargs) -> T_Dataclass:
         """
         Validate an input dictionary according to the specified dataclass. Returns an instance of the dataclass.
         """
         # Validate raw dictionary using underlying DictValidator
-        validated_dict = super().validate(input_data)
+        validated_dict = super().validate(input_data, **kwargs)
 
         # Fill optional fields with default values
         for field_name, field_default in self.field_defaults.items():

--- a/src/validataclass/validators/dict_validator.py
+++ b/src/validataclass/validators/dict_validator.py
@@ -122,7 +122,7 @@ class DictValidator(Validator):
         if optional_fields is not None:
             self.required_fields = self.required_fields - set(optional_fields)
 
-    def validate(self, input_data: Any) -> dict:
+    def validate(self, input_data: Any, **kwargs) -> dict:
         """
         Validate input data. Returns a validated dict.
         """
@@ -154,7 +154,7 @@ class DictValidator(Validator):
 
             # Run field validator and catch validation errors
             try:
-                validated_dict[key] = field_validator.validate(value)
+                validated_dict[key] = field_validator.validate_with_context(value, **kwargs)
             except ValidationError as error:
                 field_errors[key] = error
 

--- a/src/validataclass/validators/list_validator.py
+++ b/src/validataclass/validators/list_validator.py
@@ -56,7 +56,9 @@ class ListValidator(Validator):
     discard_invalid: bool = False
 
     def __init__(
-        self, item_validator: Validator, *,
+        self,
+        item_validator: Validator,
+        *,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
         discard_invalid: bool = False
@@ -85,7 +87,7 @@ class ListValidator(Validator):
         self.max_length = max_length
         self.discard_invalid = discard_invalid
 
-    def validate(self, input_data: Any) -> list:
+    def validate(self, input_data: Any, **kwargs) -> list:
         """
         Validate input data. Returns a validated list.
         """
@@ -103,7 +105,7 @@ class ListValidator(Validator):
         # Apply item_validator to all list items and collect validation errors
         for index, item in enumerate(input_data):
             try:
-                validated_list.append(self.item_validator.validate(item))
+                validated_list.append(self.item_validator.validate_with_context(item, **kwargs))
             except ValidationError as error:
                 validation_errors[index] = error
 

--- a/src/validataclass/validators/noneable.py
+++ b/src/validataclass/validators/noneable.py
@@ -62,7 +62,7 @@ class Noneable(Validator):
         self.wrapped_validator = validator
         self.default_value = default
 
-    def validate(self, input_data: Any) -> Optional[Any]:
+    def validate(self, input_data: Any, **kwargs) -> Optional[Any]:
         """
         Validate input data.
 
@@ -74,7 +74,7 @@ class Noneable(Validator):
 
         try:
             # Call wrapped validator for all values other than None
-            return self.wrapped_validator.validate(input_data)
+            return self.wrapped_validator.validate_with_context(input_data, **kwargs)
         except InvalidTypeError as error:
             # If wrapped validator raises an InvalidTypeError, add 'none' to its 'expected_types' list and reraise it
             error.add_expected_type(type(None))

--- a/src/validataclass/validators/validator.py
+++ b/src/validataclass/validators/validator.py
@@ -4,6 +4,7 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
+import inspect
 from abc import ABC, abstractmethod
 from typing import Any, Union, List
 
@@ -26,6 +27,27 @@ class Validator(ABC):
         Returns sanitized data or raises a `ValidationError` (or any subclass).
         """
         raise NotImplementedError()
+
+    def validate_with_context(self, input_data: Any, **kwargs):
+        """
+        This method is a wrapper for `validate()` that always accepts arbitrary keyword arguments (which can be used
+        for context-sensitive validation).
+
+        If the `validate()` method of this class supports arbitrary keyword arguments, the keyword arguments are passed
+        to the `validate()` method. Otherwise, the `validate()` method is called only with the input value and no other
+        arguments.
+
+        NOTE: This method is only needed for compatibility reasons and will become obsolete in the future, when every
+        Validator class will be required to accept arbitrary keyword arguments (probably in version 1.0).
+
+        Use this method only if you want/need to pass context arguments to a validator and don't know for sure that the
+        validator accepts keyword arguments (e.g. because you don't know the class of the validator).
+        """
+        validate_spec = inspect.getfullargspec(self.validate)
+        if validate_spec.varkw is not None:
+            return self.validate(input_data, **kwargs)  # noqa (unexpected argument)
+        else:
+            return self.validate(input_data)
 
     @staticmethod
     def _ensure_not_none(input_data: Any) -> None:

--- a/src/validataclass/validators/validator.py
+++ b/src/validataclass/validators/validator.py
@@ -43,8 +43,7 @@ class Validator(ABC):
         Use this method only if you want/need to pass context arguments to a validator and don't know for sure that the
         validator accepts keyword arguments (e.g. because you don't know the class of the validator).
         """
-        validate_spec = inspect.getfullargspec(self.validate)
-        if validate_spec.varkw is not None:
+        if inspect.getfullargspec(self.validate).varkw is not None:
             return self.validate(input_data, **kwargs)  # noqa (unexpected argument)
         else:
             return self.validate(input_data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,9 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import List
+from typing import Any, List
 
+from validataclass.validators import Validator
 
 def unpack_params(*args) -> List[tuple]:
     """
@@ -69,3 +70,22 @@ def unpack_params(*args) -> List[tuple]:
 
 # This is a sentinel object used in parametrized tests to represent "this parameter should not be set"
 UNSET_PARAMETER = object()
+
+
+# Test validator that parses context arguments
+class UnitTestContextValidator(Validator):
+    """
+    Context-sensitive string validator, only for unit testing.
+
+    Returns the input string followed by a dump of the context arguments, optionally with a prefix string.
+    """
+
+    # Prefix that is prepended to the output to distinguish multiple validators in tests
+    prefix: str
+
+    def __init__(self, *, prefix: str = ''):
+        self.prefix = f'[{prefix}] ' if prefix else ''
+
+    def validate(self, input_data: Any, **kwargs) -> str:
+        self._ensure_type(input_data, str)
+        return f'{self.prefix}{input_data} / {kwargs}'

--- a/tests/test_utils_test.py
+++ b/tests/test_utils_test.py
@@ -4,7 +4,7 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from tests.test_utils import unpack_params
+from tests.test_utils import unpack_params, UnitTestContextValidator
 
 
 class UnpackParamsTest:
@@ -54,3 +54,18 @@ class UnpackParamsTest:
             ('baz', 'BAZ', 2, 'b'),
             ('baz', 'BAZ', 3, 'c'),
         ]
+
+
+class UnitTestContextValidatorTest:
+    """ Tests for the UnitTestContextValidator helper validator. """
+
+    @staticmethod
+    def test_validator():
+        validator = UnitTestContextValidator()
+        assert validator.validate('banana') == 'banana / {}'
+        assert validator.validate('banana', foo=42, bar=[]) == "banana / {'foo': 42, 'bar': []}"
+
+    @staticmethod
+    def test_validator_with_prefix():
+        validator = UnitTestContextValidator(prefix='UNITTEST')
+        assert validator.validate('banana', foo=42, bar=[]) == "[UNITTEST] banana / {'foo': 42, 'bar': []}"

--- a/tests/validators/dataclass_validator_test.py
+++ b/tests/validators/dataclass_validator_test.py
@@ -10,6 +10,7 @@ from typing import Optional, List
 
 import pytest
 
+from tests.test_utils import UnitTestContextValidator
 from validataclass.dataclasses import validataclass, validataclass_field, Default, DefaultFactory, DefaultUnset
 from validataclass.exceptions import ValidationError, RequiredValueError, DictFieldsValidationError, DataclassPostValidationError, \
     InvalidValidatorOptionException, DataclassValidatorFieldException
@@ -176,6 +177,26 @@ class DataclassValidatorTest:
 
         # Verify that the default list was deepcopied
         assert validated_objects[1].default_list is not validated_objects[2].default_list is not validated_objects[3].default_list
+
+    # Tests for DataclassValidator with context arguments
+
+    @staticmethod
+    def test_validation_with_context_arguments():
+        """ Test that DataclassValidator passes context arguments down to the field validators. """
+
+        @validataclass
+        class DataclassWithContextSensitiveValidators:
+            field1: str = UnitTestContextValidator(prefix='1')
+            field2: str = UnitTestContextValidator(prefix='2')
+
+        validator = DataclassValidator(DataclassWithContextSensitiveValidators)
+        validated_data = validator.validate({
+            'field1': 'apple',
+            'field2': 'banana',
+        }, foo=42)
+
+        assert validated_data.field1 == "[1] apple / {'foo': 42}"
+        assert validated_data.field2 == "[2] banana / {'foo': 42}"
 
     # Tests for more complex and nested validators using dataclasses
 

--- a/tests/validators/dict_validator_test.py
+++ b/tests/validators/dict_validator_test.py
@@ -7,6 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from decimal import Decimal
 import pytest
 
+from tests.test_utils import UnitTestContextValidator
 from validataclass.exceptions import DictFieldsValidationError, DictInvalidKeyTypeError, InvalidTypeError, RequiredValueError, \
     InvalidValidatorOptionException, ListItemsValidationError
 from validataclass.validators import DictValidator, DecimalValidator, IntegerValidator, StringValidator, Noneable, ListValidator
@@ -306,6 +307,29 @@ class DictValidatorTest:
         assert validated_data == {
             'test_a': Decimal('13.37'),
             'test_b': None,
+        }
+
+    # Tests for DictValidator with context arguments
+
+    @staticmethod
+    def test_with_context_arguments():
+        """ Test that DictValidator passes context arguments down to the default and field validators. """
+        validator = DictValidator(
+            field_validators={'unittest': UnitTestContextValidator(prefix='FIELD')},
+            default_validator=UnitTestContextValidator(prefix='DEFAULT'),
+        )
+        input_dict = {
+            'unittest': 'foo',
+            'foobar': 'bar',
+        }
+
+        assert validator.validate(input_dict) == {
+            'unittest': "[FIELD] foo / {}",
+            'foobar': "[DEFAULT] bar / {}",
+        }
+        assert validator.validate(input_dict, foo=42) == {
+            'unittest': "[FIELD] foo / {'foo': 42}",
+            'foobar': "[DEFAULT] bar / {'foo': 42}",
         }
 
     # Test invalid validator options

--- a/tests/validators/list_validator_test.py
+++ b/tests/validators/list_validator_test.py
@@ -7,6 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from decimal import Decimal
 import pytest
 
+from tests.test_utils import UnitTestContextValidator
 from validataclass.exceptions import RequiredValueError, InvalidTypeError, ListItemsValidationError, ListLengthError, \
     InvalidValidatorOptionException
 from validataclass.validators import ListValidator, IntegerValidator, StringValidator, DecimalValidator
@@ -93,6 +94,21 @@ class ListValidatorTest:
                 3: {'code': 'invalid_decimal'},
             }
         }
+
+    # Test ListValidator with a context-sensitive item validator
+
+    @staticmethod
+    def test_with_context_arguments():
+        """ Test that ListValidator passes context arguments down to the item validator. """
+        validator = ListValidator(item_validator=UnitTestContextValidator())
+        assert validator.validate(['unit', 'test']) == [
+            "unit / {}",
+            "test / {}",
+        ]
+        assert validator.validate(['unit', 'test'], foo=42) == [
+            "unit / {'foo': 42}",
+            "test / {'foo': 42}",
+        ]
 
     # Check that ListValidator actually discards invalid items
 

--- a/tests/validators/noneable_test.py
+++ b/tests/validators/noneable_test.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 import pytest
 
+from tests.test_utils import UnitTestContextValidator
 from validataclass.exceptions import ValidationError
 from validataclass.validators import Noneable, DecimalValidator, IntegerValidator
 
@@ -48,6 +49,14 @@ class NoneableTest:
 
         assert type(result) == type(expected_result)
         assert result == expected_result
+
+    @staticmethod
+    def test_noneable_with_context_arguments():
+        """ Test that Noneable passes context arguments down to the wrapped validator. """
+        validator = Noneable(UnitTestContextValidator())
+        assert validator.validate(None) is None
+        assert validator.validate('unittest') == "unittest / {}"
+        assert validator.validate('unittest', foo=42) == "unittest / {'foo': 42}"
 
     @staticmethod
     def test_invalid_not_none_value():


### PR DESCRIPTION
This PR adds a nice, new feature I was planning on implementing for a while now: Context-sensitive validation.

You can now pass arbitrary keyword arguments to the `validate()` method. Most validators won't do anything with those (except passing them to child validators, e.g. in lists or dataclasses), but you can now implement validators that can be influenced by passing additional arguments at validation time.

Additionally, the `DataclassValidator` now checks whether a dataclass has a `__post_validate__()` method. If yes, this method is called after creating the dataclass instance. This method can also take context arguments for context-sensitive post-validation. 

All library validators were adjusted to accept arbitrary keyword arguments. Existing custom validators will keep working for now, but definitely should be updated to accept them too (just add `**kwargs` to the parameters). A DeprecationWarning will be issued if a validator class does not support this yet.

For compatibility, a helper method `validate_with_context()` was added to the base Validator class that can be used as a failsafe method to call a validator. If the validator class already supports context arguments, it will pass these to `validate()`, otherwise `validate()` will be called without any extra arguments.

This PR also **removes** a small feature that (hopefully) nobody has used anyway: When subclassing DataclassValidator, you could override the method `post_validate()` which was called by `validate()`. It is recommended to just use `__post_validate__()` or `__post_init__()` in the dataclass itself instead, or to override the whole `validate()` method (which was a bit refactored so you can reuse parts of it, see code).