### PR TITLE
Use @dataclass_transform decorator on @validataclass decorator via typing-extensions (#75)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ build~=0.7
 pytest~=6.2
 pytest-cov~=2.12
 coverage-conditional-plugin~=0.5
+typing-extensions ~= 4.3
 python-dateutil~=2.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
+    typing-extensions ~= 4.3
     python-dateutil
 
 [options.packages.find]

--- a/src/validataclass/dataclasses/validataclass.py
+++ b/src/validataclass/dataclasses/validataclass.py
@@ -9,6 +9,8 @@ import sys
 from collections import namedtuple
 from typing import Union, Dict
 
+from typing_extensions import dataclass_transform
+
 from validataclass.exceptions import DataclassValidatorFieldException
 from validataclass.validators import Validator
 from .defaults import Default, NoDefault
@@ -22,6 +24,10 @@ __all__ = [
 _ValidatorField = namedtuple('_ValidatorField', ['validator', 'default'])
 
 
+@dataclass_transform(
+    kw_only_default=True,
+    field_specifiers=(dataclasses.field, dataclasses.Field, validataclass_field),
+)
 def validataclass(cls=None, **kwargs):
     """
     Decorator that turns a normal class into a DataclassValidator-compatible dataclass.


### PR DESCRIPTION
This PR applies the new `@dataclass_transform` decorator (PEP 681) on the `@validataclass` decorator.

Since this decorator was only introduced in Python 3.11, we're using the typing-extensions library here which backports some newer typing features.

Solves #75.