### PR TITLE
DateTimeValidator: Add discard_milliseconds parameter (#74)

### DIFF
--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -674,6 +674,11 @@ Example input               | `ALLOW_TIMEZONE` | `REQUIRE_TIMEZONE` | `REQUIRE_U
 `2021-12-31T12:34:56+02:00` | valid            | valid              |               |              |
 
 
+Regardless of the specified format, the validator always accepts input strings with milli- and microseconds (e.g.
+"2021-12-31T12:34:56.123" or "2021-12-31T12:34:56.123456"). This cannot be changed currently. However, you can set the
+option `discard_milliseconds=True`, which will discard the milli- and microseconds of the output datetime (both of the
+examples would then result in the same datetime as "2021-12-31T12:34:56").
+
 The parameter `local_timezone` can be used to set the timezone for datetime strings that don't specify a timezone. For example, if
 `local_timezone` is set to a UTC+3 timezone, the string `"2021-12-31T12:34:56"` will be treated like `"2021-12-31T12:34:56+03:00"`.
 Similarly, to interpret datetimes without timezone as UTC, set `local_timezone=datetime.timezone.utc`. If `local_timezone` is not

--- a/tests/validators/datetime_validator_test.py
+++ b/tests/validators/datetime_validator_test.py
@@ -227,6 +227,31 @@ class DateTimeValidatorTest:
             'datetime_format': datetime_format_str,
         }
 
+    # Test DateTimeValidator with discard_milliseconds parameter
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_string, expected_datetime', [
+            # Without timezone
+            ('2021-09-01T12:34:56', datetime(2021, 9, 1, 12, 34, 56)),
+            ('2021-09-01T12:34:56.000', datetime(2021, 9, 1, 12, 34, 56)),
+            ('2021-09-01T12:34:56.123', datetime(2021, 9, 1, 12, 34, 56)),
+            ('2021-09-01T12:34:56.999999', datetime(2021, 9, 1, 12, 34, 56)),
+
+            # With timezone
+            ('2021-09-01T12:34:56+01:00', datetime(2021, 9, 1, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
+            ('2021-09-01T12:34:56.000+01:00', datetime(2021, 9, 1, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
+            ('2021-09-01T12:34:56.123+01:00', datetime(2021, 9, 1, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
+            ('2021-09-01T12:34:56.999999+01:00', datetime(2021, 9, 1, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
+        ]
+    )
+    def test_with_discard_milliseconds(input_string, expected_datetime):
+        """ Test DateTimeValidator with discard_milliseconds set to True. """
+        validator = DateTimeValidator(DateTimeFormat.ALLOW_TIMEZONE, discard_milliseconds=True)
+        validated_datetime = validator.validate(input_string)
+        assert validated_datetime == expected_datetime
+        assert validated_datetime.microsecond == 0
+
     # Test DateTimeValidator with local_timezone parameter
 
     @staticmethod


### PR DESCRIPTION
This PR adds a new boolean parameter `discard_milliseconds` to `DateTimeValidator`. (See #74.)

If set, milli- and microseconds will be set to 0 in the output datetime.