### PR TITLE
Miscellaneous improvements to ListValidator, AnyOfValidator, EnumValidator

### DIFF
--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -838,7 +838,8 @@ These values can potentially be of any type, although strings and integers are p
 The `AnyOfValidator` is defined with a simple list of allowed values and accepts only values that are part of this list.
 The values will be returned unmodified.
 
-The list of allowed values may contain mixed types (e.g. `['banana', 123, True, None]`).
+The list of allowed values may contain mixed types (e.g. `['banana', 123, True, None]`). Also the allowed values can be
+specified with any iterable, not just as a list (e.g. as a set or tuple).
 
 Like most other validators, the validator will first check the type of input data and will raise an `InvalidTypeError` for types that
 are not allowed. Those allowed types will be automatically determined from the list of values by default (e.g. with `['foo', 'bar', 'baz']`

--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -884,12 +884,17 @@ The `EnumValidator` is an extended `AnyOfValidator` that uses `Enum` classes ins
 
 It accepts the **values** of the Enum and converts the input value to the according enum **member**.
 
-By default all values in the Enum are accepted as input. This can be optionally restricted by specifying the `allowed_values`
-parameter, which will override the list of allowed values. Values in this list that are not valid for the Enum will be silently
-ignored though.
+By default all values in the Enum are accepted as input. This can be optionally restricted by specifying the
+`allowed_values` parameter, which will override the list of allowed values. Values in this list that are not valid for
+the Enum will be silently ignored.
 
-The types allowed for input data will be automatically determined from the allowed Enum values by default, unless explicitly
-specified with the parameter `allowed_types`.
+If you just want to disallow certain values without manually specifying all of the allowed values, you can specify the
+`allowed_values` parameter as a set and use some set magic. For example, `allowed_values=set(MyEnum) - {MyEnum.BadValue}`
+would allow all values of `MyEnum` except for `MyEnum.BadValue`.
+
+
+The types allowed for input data will be automatically determined from the allowed Enum values by default, unless
+explicitly specified with the parameter `allowed_types`.
 
 **Examples:**
 
@@ -935,6 +940,12 @@ validator.validate('pineapple')   # will raise ValueNotAllowedError (value is no
 
 # Restrict allowed values using the Enum instead of strings
 validator = EnumValidator(ExampleStringEnum, allowed_values=[ExampleStringEnum.APPLE, ExampleStringEnum.BANANA])
+validator.validate('apple')       # will return ExampleStringEnum.APPLE
+validator.validate('banana')      # will return ExampleStringEnum.BANANA
+validator.validate('strawberry')  # will raise ValueNotAllowedError
+
+# Disallow a specific value without manually listing all allowed values
+validator = EnumValidator(ExampleStringEnum, allowed_values=set(ExampleStringEnum) - {ExampleStringEnum.STRAWBERRY})
 validator.validate('apple')       # will return ExampleStringEnum.APPLE
 validator.validate('banana')      # will return ExampleStringEnum.BANANA
 validator.validate('strawberry')  # will raise ValueNotAllowedError

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -22,7 +22,7 @@ from .reject_validator import RejectValidator
 # Extended type validators
 from .any_of_validator import AnyOfValidator
 from .big_integer_validator import BigIntegerValidator
-from .enum_validator import EnumValidator
+from .enum_validator import EnumValidator, T_Enum
 from .decimal_validator import DecimalValidator
 from .float_to_decimal_validator import FloatToDecimalValidator
 from .numeric_validator import NumericValidator
@@ -34,6 +34,6 @@ from .email_validator import EmailValidator
 from .url_validator import UrlValidator
 
 # Composite type validators
-from .list_validator import ListValidator
+from .list_validator import ListValidator, T_ListItem
 from .dict_validator import DictValidator
 from .dataclass_validator import DataclassValidator, T_Dataclass

--- a/src/validataclass/validators/dataclass_validator.py
+++ b/src/validataclass/validators/dataclass_validator.py
@@ -22,7 +22,7 @@ __all__ = [
 T_Dataclass = TypeVar('T_Dataclass')
 
 
-class DataclassValidator(DictValidator, Generic[T_Dataclass]):
+class DataclassValidator(Generic[T_Dataclass], DictValidator):
     """
     Validator that converts dictionaries to instances of user-defined dataclasses with validated fields.
 

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -5,17 +5,21 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from enum import Enum, EnumMeta
-from typing import Any, Type, Union, List
+from typing import Any, Generic, List, Type, TypeVar, Union
 
-from .any_of_validator import AnyOfValidator
 from validataclass.exceptions import InvalidValidatorOptionException, ValueNotAllowedError
+from .any_of_validator import AnyOfValidator
 
 __all__ = [
     'EnumValidator',
+    'T_Enum',
 ]
 
+# Type variable for type hints in DataclassValidator
+T_Enum = TypeVar('T_Enum', bound=Enum)
 
-class EnumValidator(AnyOfValidator):
+
+class EnumValidator(Generic[T_Enum], AnyOfValidator):
     """
     Validator that uses an Enum class to parse input values to members of that enumeration.
 
@@ -80,7 +84,7 @@ class EnumValidator(AnyOfValidator):
         # Initialize base AnyOfValidator
         super().__init__(allowed_values=any_of_values, allowed_types=allowed_types)
 
-    def validate(self, input_data: Any, **kwargs) -> Enum:
+    def validate(self, input_data: Any, **kwargs) -> T_Enum:
         """
         Validate input to be a valid value of the specified Enum. Returns the Enum member.
         """

--- a/src/validataclass/validators/list_validator.py
+++ b/src/validataclass/validators/list_validator.py
@@ -4,17 +4,21 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Any, Optional
+from typing import Any, Generic, List, Optional, TypeVar
 
-from .validator import Validator
 from validataclass.exceptions import ValidationError, ListItemsValidationError, ListLengthError, InvalidValidatorOptionException
+from .validator import Validator
 
 __all__ = [
     'ListValidator',
+    'T_ListItem',
 ]
 
+# Type variable for type hints in DataclassValidator
+T_ListItem = TypeVar('T_ListItem')
 
-class ListValidator(Validator):
+
+class ListValidator(Generic[T_ListItem], Validator):
     """
     Validator for lists that validates list items with a specified item validator.
 
@@ -87,7 +91,7 @@ class ListValidator(Validator):
         self.max_length = max_length
         self.discard_invalid = discard_invalid
 
-    def validate(self, input_data: Any, **kwargs) -> list:
+    def validate(self, input_data: Any, **kwargs) -> List[T_ListItem]:
         """
         Validate input data. Returns a validated list.
         """

--- a/tests/validators/any_of_validator_test.py
+++ b/tests/validators/any_of_validator_test.py
@@ -52,12 +52,12 @@ class AnyOfValidatorTest:
             'expected_type': 'str',
         }
 
-    # Test AnyOfValidator with a integer value list
+    # Test AnyOfValidator with a set of integer values
 
     @staticmethod
     def test_integer_values_valid():
         """ Test AnyOfValidator with integer value list with valid input. """
-        validator = AnyOfValidator([0, 1, -2, 42])
+        validator = AnyOfValidator({0, 1, -2, 42})
         assert validator.validate(0) == 0
         assert validator.validate(1) == 1
         assert validator.validate(-2) == -2
@@ -67,7 +67,7 @@ class AnyOfValidatorTest:
     @pytest.mark.parametrize('input_data', [0, 2, 13])
     def test_integer_values_invalid_value(input_data):
         """ Test AnyOfValidator with integer value list with invalid input. """
-        validator = AnyOfValidator([1, -2, 42])
+        validator = AnyOfValidator({1, -2, 42})
         with pytest.raises(ValueNotAllowedError) as exception_info:
             validator.validate(input_data)
         assert exception_info.value.to_dict() == {'code': 'value_not_allowed'}
@@ -76,7 +76,7 @@ class AnyOfValidatorTest:
     @pytest.mark.parametrize('input_data', ['banana', 1.234, True, [1]])
     def test_integer_values_invalid_type(input_data):
         """ Check that AnyOfValidator with integer value list raises an exception for values with wrong type. """
-        validator = AnyOfValidator([0, 1, -2, 42])
+        validator = AnyOfValidator({0, 1, -2, 42})
         with pytest.raises(InvalidTypeError) as exception_info:
             validator.validate(input_data)
         assert exception_info.value.to_dict() == {
@@ -84,12 +84,12 @@ class AnyOfValidatorTest:
             'expected_type': 'int',
         }
 
-    # Test AnyOfValidator with a mixed type value list
+    # Test AnyOfValidator with allowed values of mixed types as a tuple
 
     @staticmethod
     def test_mixed_values_valid():
-        """ Test AnyOfValidator with mixed value list with valid input. """
-        validator = AnyOfValidator(['strawberry', 42, None])
+        """ Test AnyOfValidator with allowed values of mixed types with valid input. """
+        validator = AnyOfValidator(allowed_values=('strawberry', 42, None))
         assert validator.validate('strawberry') == 'strawberry'
         assert validator.validate(42) == 42
         assert validator.validate(None) is None
@@ -97,8 +97,8 @@ class AnyOfValidatorTest:
     @staticmethod
     @pytest.mark.parametrize('input_data', [0, 13, '', 'banana'])
     def test_mixed_values_invalid_value(input_data):
-        """ Test AnyOfValidator with mixed value list with invalid input. """
-        validator = AnyOfValidator(['strawberry', 42, None])
+        """ Test AnyOfValidator with allowed values of mixed types with invalid input. """
+        validator = AnyOfValidator(allowed_values=('strawberry', 42, None))
         with pytest.raises(ValueNotAllowedError) as exception_info:
             validator.validate(input_data)
         assert exception_info.value.to_dict() == {'code': 'value_not_allowed'}
@@ -106,8 +106,8 @@ class AnyOfValidatorTest:
     @staticmethod
     @pytest.mark.parametrize('input_data', [1.234, True, False, [1], ['strawberry']])
     def test_mixed_values_invalid_type(input_data):
-        """ Check that AnyOfValidator with mixed value list raises an exception for values with wrong type. """
-        validator = AnyOfValidator(['strawberry', 42, None])
+        """ Check that AnyOfValidator with allowed values of mixed types raises an exception for values with wrong type. """
+        validator = AnyOfValidator(allowed_values=('strawberry', 42, None))
         with pytest.raises(InvalidTypeError) as exception_info:
             validator.validate(input_data)
         assert exception_info.value.to_dict() == {

--- a/tests/validators/enum_validator_test.py
+++ b/tests/validators/enum_validator_test.py
@@ -155,6 +155,20 @@ class EnumValidatorTest:
             validator.validate(input_data)
         assert exception_info.value.to_dict() == {'code': 'value_not_allowed'}
 
+    @staticmethod
+    def test_string_enum_allowed_values_as_set():
+        """ Test EnumValidator with string based Enum that disallows a certain value. """
+        # Also tests using enum members in allowed_values
+        validator = EnumValidator(UnitTestStringEnum, allowed_values=set(UnitTestStringEnum) - {UnitTestStringEnum.STRAWBERRY})
+
+        # Check allowed values
+        assert validator.validate('red apple') is UnitTestStringEnum.APPLE_RED
+        assert validator.validate('green apple') is UnitTestStringEnum.APPLE_GREEN
+
+        # Check disallowed value
+        with pytest.raises(ValueNotAllowedError):
+            validator.validate('strawberry')
+
     # Test EnumValidator with explicit allowed_types parameter
 
     @staticmethod


### PR DESCRIPTION
This PR contains some smaller improvements:

- `ListValidator` is now a generic class (e.g. `ListValidator[int]`)
- `EnumValidator` is now a generic class (e.g. `EnumValidator[ExampleEnum]`) (#73)
- `AnyOfValidator` and `EnumValidator` now accept the `allowed_values` and `allowed_types` parameters as any iterable instead of only as a list (#37)