### PR TITLE
EmailValidator: Add parameter "allow_empty" (#86)

### DIFF
--- a/src/validataclass/validators/email_validator.py
+++ b/src/validataclass/validators/email_validator.py
@@ -28,7 +28,7 @@ class EmailValidator(StringValidator):
     in the future), nor oddities like quoted strings as local part or comments, because most mail software does not support those anyway
     and/or might break with those addresses.
 
-    Set the parameter `allow_empty=True` to allow empty strings, e.g. '' or ' '.
+    Set the parameter `allow_empty=True` to allow empty strings ('').
 
     Example:
 
@@ -63,10 +63,8 @@ class EmailValidator(StringValidator):
         """
         self.allow_empty = allow_empty
 
-        min_length = 1
         # Allow string with length 0 if `allow_empty=True`
-        if allow_empty:
-            min_length = 0
+        min_length = 0 if allow_empty else 1
 
         # Initialize StringValidator with some length requirements
         super().__init__(min_length=min_length, max_length=256)
@@ -79,7 +77,7 @@ class EmailValidator(StringValidator):
         input_email = super().validate(input_data, **kwargs)
 
         # Allow empty strings (also strings consisting only of spaces) if `allow_empty=True`
-        if self.allow_empty and input_email.strip() == "":
+        if self.allow_empty and input_email == "":
             return input_email
 
         # Validate string with regular expression

--- a/src/validataclass/validators/regex_validator.py
+++ b/src/validataclass/validators/regex_validator.py
@@ -42,6 +42,8 @@ class RegexValidator(StringValidator):
     By default only "safe" singleline strings are allowed (i.e. no non-printable characters). See the `StringValidator`
     options `unsafe` and `multiline` for more details.
 
+    Set the parameter `allow_empty=True` to allow empty strings, e.g. '' or ' '.
+
     Examples:
 
     ```
@@ -72,6 +74,9 @@ class RegexValidator(StringValidator):
         code = 'invalid_hex_number'
 
     RegexValidator(re.compile(r'[0-9a-f]+'), custom_error_class=InvalidHexNumberError)
+
+    # Accepts also empty strings
+    RegexValidator(r'[0-9a-fA-F]+', allow_empty=True)
     ```
 
     Valid input: Any `str` that matches the regex
@@ -90,6 +95,9 @@ class RegexValidator(StringValidator):
     # Custom error code to use in the regex match exception (use default if None)
     custom_error_code: Optional[str]
 
+    # Whether to accept empty strings
+    allow_empty: bool = False
+
     def __init__(
         self,
         pattern: Union[re.Pattern, str],
@@ -97,6 +105,7 @@ class RegexValidator(StringValidator):
         *,
         custom_error_class: Type[ValidationError] = RegexMatchError,
         custom_error_code: Optional[str] = None,
+        allow_empty: bool = False,
         **kwargs,
     ):
         """
@@ -110,6 +119,7 @@ class RegexValidator(StringValidator):
             output_template: Optional `str`, template to be used in output, will be supplied to match.expand() (default: None)
             custom_error_class: Subclass of `ValidationError` raised when regex matching fails (default: RegexMatchError)
             custom_error_code: Optional `str`, overrides the default error code in the regex match exception (default: None)
+            allow_empty: Boolean, if True, empty strings are accepted as valid (default: False)
         """
         # Initialize base StringValidator (may set min_length/max_length via kwargs)
         super().__init__(**kwargs)
@@ -131,6 +141,8 @@ class RegexValidator(StringValidator):
         self.custom_error_class = custom_error_class
         self.custom_error_code = custom_error_code
 
+        self.allow_empty = allow_empty
+
     def validate(self, input_data: Any, **kwargs) -> str:
         """
         Validate input as string and match full string against regular expression.
@@ -143,8 +155,11 @@ class RegexValidator(StringValidator):
         # Match full string against Regex pattern
         match = self.regex_pattern.fullmatch(input_data)
 
-        # Raise error if match not found
-        if not match:
+        # Find out if allow_empty parameter set and relevant
+        allow_empty_relevant = self.allow_empty and input_data.strip() == ""
+
+        # Raise error if match not found and allow empty not set or data is not empty string
+        if not match and not allow_empty_relevant:
             raise self.custom_error_class(code=self.custom_error_code)
 
         # Expand template if output_template was supplied

--- a/src/validataclass/validators/regex_validator.py
+++ b/src/validataclass/validators/regex_validator.py
@@ -42,7 +42,7 @@ class RegexValidator(StringValidator):
     By default only "safe" singleline strings are allowed (i.e. no non-printable characters). See the `StringValidator`
     options `unsafe` and `multiline` for more details.
 
-    Set the parameter `allow_empty=True` to allow empty strings, e.g. '' or ' '.
+    Set the parameter `allow_empty=True` to allow empty strings ('').
 
     Examples:
 
@@ -152,14 +152,15 @@ class RegexValidator(StringValidator):
         # Validate input with base StringValidator (checks length requirements)
         output = super().validate(input_data, **kwargs)
 
+        # Find out if allow_empty parameter set and relevant
+        if self.allow_empty and output == "":
+            return output
+
         # Match full string against Regex pattern
         match = self.regex_pattern.fullmatch(input_data)
 
-        # Find out if allow_empty parameter set and relevant
-        allow_empty_relevant = self.allow_empty and input_data.strip() == ""
-
-        # Raise error if match not found and allow empty not set or data is not empty string
-        if not match and not allow_empty_relevant:
+        # Raise error if match not found
+        if not match:
             raise self.custom_error_class(code=self.custom_error_code)
 
         # Expand template if output_template was supplied

--- a/tests/validators/email_validator_test.py
+++ b/tests/validators/email_validator_test.py
@@ -44,6 +44,30 @@ class EmailValidatorTest:
             'max_length': 256,
         }
 
+    # Test optional allow_empty parameter
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_string', [
+            # Empty strings
+            '',
+            ' ',
+            '  ',
+            # Regular addresses (with some odd but valid characters)
+            'a@example.com',
+            '~foo-123+bar{banana}@some.sub.domain.example.com',
+            # Addresses with dots at valid positions
+            'foo.bar@example.com',
+            'a.b.c.d.e@example.com',
+            # Very long local part (up to 64 characters are allowed)
+            'fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo@example.com'
+        ]
+    )
+    def test_allow_empty_valid(input_string):
+        """ Check that EmailValidator returns empty string if boolean parameter allow_empty=True. """
+        validator = EmailValidator(allow_empty=True)
+        assert validator.validate(input_string) == input_string
+
     @staticmethod
     def test_invalid_string_too_long():
         """ Check that EmailValidator raises exceptions for strings that are too long. """

--- a/tests/validators/email_validator_test.py
+++ b/tests/validators/email_validator_test.py
@@ -51,16 +51,8 @@ class EmailValidatorTest:
         'input_string', [
             # Empty strings
             '',
-            ' ',
-            '  ',
-            # Regular addresses (with some odd but valid characters)
+            # Regular addresses
             'a@example.com',
-            '~foo-123+bar{banana}@some.sub.domain.example.com',
-            # Addresses with dots at valid positions
-            'foo.bar@example.com',
-            'a.b.c.d.e@example.com',
-            # Very long local part (up to 64 characters are allowed)
-            'fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo@example.com'
         ]
     )
     def test_allow_empty_valid(input_string):

--- a/tests/validators/regex_validator_test.py
+++ b/tests/validators/regex_validator_test.py
@@ -68,6 +68,47 @@ class RegexValidatorTest:
         for valid_input in valid_input_list:
             assert validator.validate(valid_input) == valid_input
 
+    # Test optional allow_empty parameter
+    @staticmethod
+    @pytest.mark.parametrize(
+        'regex_pattern, valid_input_list', [
+            (r'', ['', ' ']),
+            (r'banana', ['', ' ']),
+            (r'^banana$', ['', ' ']),
+            (r'.*', ['', ' ']),
+            (r'[0-9]+', ['', ' ']),
+            (r'[0-9]+.*', ['', ' ']),
+            (r'\w+\.(png|jpg)', ['', ' ']),
+        ]
+    )
+    def test_allow_empty_valid(regex_pattern, valid_input_list):
+        """ Test RegexValidator with parameter allow_empty set to True and empty strings as input. """
+        precompiled_pattern = re.compile(regex_pattern)
+        validator = RegexValidator(precompiled_pattern, allow_empty=True)
+
+        for valid_input in valid_input_list:
+            assert validator.validate(valid_input) == valid_input
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'regex_pattern, invalid_input_list', [
+            (r'banana', ['', ' ']),
+            (r'^banana$', ['', ' ']),
+            (r'[0-9]+', ['', ' ']),
+            (r'[0-9]+.*', ['', ' ']),
+            (r'\w+\.(png|jpg)', ['', ' ']),
+        ]
+    )
+    def test_allow_empty_invalid(regex_pattern, invalid_input_list):
+        """ Test RegexValidator with parameter allow_empty not set and empty strings as input. """
+        precompiled_pattern = re.compile(regex_pattern)
+        validator = RegexValidator(precompiled_pattern)
+
+        for invalid_input in invalid_input_list:
+            with pytest.raises(RegexMatchError) as exception_info:
+                validator.validate(invalid_input)
+            assert exception_info.value.to_dict() == {'code': 'invalid_string_format'}
+
     @staticmethod
     @pytest.mark.parametrize(
         'regex_pattern, invalid_input_list', [

--- a/tests/validators/regex_validator_test.py
+++ b/tests/validators/regex_validator_test.py
@@ -72,13 +72,7 @@ class RegexValidatorTest:
     @staticmethod
     @pytest.mark.parametrize(
         'regex_pattern, valid_input_list', [
-            (r'', ['', ' ']),
-            (r'banana', ['', ' ']),
-            (r'^banana$', ['', ' ']),
-            (r'.*', ['', ' ']),
-            (r'[0-9]+', ['', ' ']),
-            (r'[0-9]+.*', ['', ' ']),
-            (r'\w+\.(png|jpg)', ['', ' ']),
+            (r'banana', ['', 'banana']),
         ]
     )
     def test_allow_empty_valid(regex_pattern, valid_input_list):
@@ -92,11 +86,7 @@ class RegexValidatorTest:
     @staticmethod
     @pytest.mark.parametrize(
         'regex_pattern, invalid_input_list', [
-            (r'banana', ['', ' ']),
-            (r'^banana$', ['', ' ']),
-            (r'[0-9]+', ['', ' ']),
-            (r'[0-9]+.*', ['', ' ']),
-            (r'\w+\.(png|jpg)', ['', ' ']),
+            (r'banana', [''])
         ]
     )
     def test_allow_empty_invalid(regex_pattern, invalid_input_list):


### PR DESCRIPTION
#86 

- Optional parameter **allow_empty** added to **EmailValidator**. If set (_allow_empty=True_) empty strings are acceepted as email addresses (e.g. '' or ' ').  Usage:

        validator_email = EmailValidator(allow_empty=True)
        validator_email.validate('')

- Optional parameter **allow_empty** added to **RegexValidator**. If set (_allow_empty=True_) empty strings are acceepted as input values (e.g. '' or ' '). Usage:

        validator_regex = RegexValidator(r'[0-9a-fA-F]+', allow_empty=True)
        validator_regex.validate('')

Tests also added. 