### PR TITLE
New wrapper validator: AllowEmptyString (#87) 

### DIFF
--- a/src/validataclass/exceptions/common_exceptions.py
+++ b/src/validataclass/exceptions/common_exceptions.py
@@ -118,9 +118,10 @@ class InvalidTypeError(ValidationError):
 
     def add_expected_type(self, new_type: Union[type, str]) -> None:
         """
-        Adds a type to 'expected_types' in an existing InvalidTypeError exception.
+        Adds a type in to 'expected_types' in an existing InvalidTypeError exception. Checks for duplicates in 'expected_types'.
         """
-        self.expected_types.append(self._type_to_string(new_type))
+        if self._type_to_string(new_type) not in self.expected_types:
+            self.expected_types.append(self._type_to_string(new_type))
 
     def to_dict(self):
         base_dict = super().to_dict()

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -18,6 +18,7 @@ from .noneable import Noneable
 from .none_to_unset_value import NoneToUnsetValue
 from .anything_validator import AnythingValidator
 from .reject_validator import RejectValidator
+from .allow_empty_string import AllowEmptyString
 
 # Extended type validators
 from .any_of_validator import AnyOfValidator

--- a/src/validataclass/validators/allow_empty_string.py
+++ b/src/validataclass/validators/allow_empty_string.py
@@ -1,0 +1,80 @@
+"""
+validataclass
+Copyright (c) 2021, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from copy import deepcopy
+from typing import Any, Optional
+
+from validataclass.exceptions import InvalidTypeError
+from .validator import Validator
+
+__all__ = [
+    'AllowEmptyString',
+]
+
+
+class AllowEmptyString(Validator):
+    """
+    Special validator that wraps another validator, but allows empty string ('') as input value.
+
+    By default, the wrapper returns empty string ('') for empty string ('') as input value. Optionally a default value
+    can be specified in the constructor that will be returned instead of empty string ('').
+
+    If the wrapped validator raises an `InvalidTypeError`, `AllowEmptyString` will add empty string ('')
+    to its 'expected_types' parameter and reraise it.
+
+    Examples:
+
+    ```
+    # Accepts strings and empty string (''), returns both unmodified (e.g. "foo" -> "foo", "" -> "")
+    AllowEmptyString(StringValidator())
+
+    # Accepts strings and empty string (''), returns a default string for empty string ('')
+     (e.g. '' -> "no value given!", but "foo" -> "foo")
+    AllowEmptyString(StringValidator(), default='no value given!')
+    ```
+
+    Valid input: `` or any data accepted by the wrapped validator
+    Output: `` (or default value specified in constructor) or the output of the wrapped validator
+    """
+
+    # Default value returned in case the input is empty string ('')
+    default_value: Any
+
+    # Validator used in case the input is not empty string ('')
+    wrapped_validator: Validator
+
+    def __init__(self, validator: Validator, *, default: Any = ''):
+        """
+        Create a AllowEmptyString wrapper validator.
+
+        Parameters:
+            validator: Validator that will be wrapped (required)
+            default: Value of any type that is returned instead of empty string ('') (default: ``)
+        """
+        # Check parameter validity
+        if not isinstance(validator, Validator):
+            raise TypeError('AllowEmptyString requires a Validator instance.')
+
+        self.wrapped_validator = validator
+        self.default_value = default
+
+    def validate(self, input_data: Any, **kwargs) -> Optional[Any]:
+        """
+        Validate input data.
+
+        If the input is empty string (''), return empty string ('') (or the value specified in the `default` parameter).
+        Otherwise, pass the input to the wrapped validator and return its result.
+        """
+        if input_data == "":
+            return deepcopy(self.default_value)
+
+        try:
+            # Call wrapped validator for all values other than empty string ('')
+            return self.wrapped_validator.validate_with_context(input_data, **kwargs)
+        except InvalidTypeError as error:
+            # If wrapped validator raises an InvalidTypeError, add '' to its 'expected_types' list and reraise it
+            error.add_expected_type(str(''))
+            raise error

--- a/src/validataclass/validators/allow_empty_string.py
+++ b/src/validataclass/validators/allow_empty_string.py
@@ -22,7 +22,7 @@ class AllowEmptyString(Validator):
     By default, the wrapper returns empty string ('') for empty string ('') as input value. Optionally a default value
     can be specified in the constructor that will be returned instead of empty string ('').
 
-    If the wrapped validator raises an `InvalidTypeError`, `AllowEmptyString` will add empty string ('')
+    If the wrapped validator raises an `InvalidTypeError`, `AllowEmptyString` will add str
     to its 'expected_types' parameter and reraise it.
 
     Examples:
@@ -75,6 +75,6 @@ class AllowEmptyString(Validator):
             # Call wrapped validator for all values other than empty string ('')
             return self.wrapped_validator.validate_with_context(input_data, **kwargs)
         except InvalidTypeError as error:
-            # If wrapped validator raises an InvalidTypeError, add '' to its 'expected_types' list and reraise it
-            error.add_expected_type(str(''))
+            # If wrapped validator raises an InvalidTypeError, add str to its 'expected_types' list and reraise it
+            error.add_expected_type(str)
             raise error

--- a/tests/exceptions/common_exceptions_test.py
+++ b/tests/exceptions/common_exceptions_test.py
@@ -130,3 +130,15 @@ class InvalidTypeErrorTest:
         # Check error after adding types
         assert repr(error) == "InvalidTypeError(code='invalid_type', expected_types=['banana', 'float', 'int'])"
         assert error.to_dict() == {'code': 'invalid_type', 'expected_types': ['banana', 'float', 'int']}
+
+    @staticmethod
+    def test_add_duplicate_to_expected_types():
+        """ Tests adding duplicate to InvalidTypeError with `add_expected_types()` should not add new expected type. """
+        error = InvalidTypeError(expected_types=[int, str])
+
+        # Add duplicate additional types
+        error.add_expected_type(int)
+
+        # Check 'int' is not added to error
+        assert repr(error) == "InvalidTypeError(code='invalid_type', expected_types=['int', 'str'])"
+        assert error.to_dict() == {'code': 'invalid_type', 'expected_types': ['int', 'str']}

--- a/tests/validators/allow_empty_string_test.py
+++ b/tests/validators/allow_empty_string_test.py
@@ -53,7 +53,7 @@ class AllowEmptyStringTest:
     def test_allow_empty_string_with_context_arguments():
         """ Test that AllowEmptyString passes context arguments down to the wrapped validator. """
         validator = AllowEmptyString(UnitTestContextValidator())
-        assert validator.validate('') is ''
+        assert validator.validate('') == ''
         assert validator.validate('unittest') == "unittest / {}"
         assert validator.validate('unittest', foo=42) == "unittest / {'foo': 42}"
 
@@ -67,13 +67,14 @@ class AllowEmptyStringTest:
 
     @staticmethod
     def test_invalid_type_contains_empty_string():
-        """ Test that AllowEmptyString adds '' to the expected_types parameter if the wrapped validator raises an InvalidTypeError. """
+        """ Test that AllowEmptyString adds str to the expected_types parameter if the wrapped validator raises an InvalidTypeError. """
         validator = AllowEmptyString(DecimalValidator())
         with pytest.raises(ValidationError) as exception_info:
             validator.validate(123)
+        print(exception_info.value.to_dict())
         assert exception_info.value.to_dict() == {
             'code': 'invalid_type',
-            'expected_types': ['', 'str'],
+            'expected_type': 'str',
         }
 
     @staticmethod

--- a/tests/validators/allow_empty_string_test.py
+++ b/tests/validators/allow_empty_string_test.py
@@ -1,0 +1,110 @@
+"""
+validataclass
+Copyright (c) 2021, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from decimal import Decimal
+
+import pytest
+from validataclass.exceptions import ValidationError
+from validataclass.validators import AllowEmptyString, DecimalValidator, IntegerValidator
+from tests.test_utils import UnitTestContextValidator
+
+
+class AllowEmptyStringTest:
+    """
+    Unit tests for the AllowEmptyString wrapper validator.
+    """
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data, expected_result',
+        [
+            ('', ''),
+            ('12.34', Decimal('12.34')),
+        ]
+    )
+    def test_allow_empty_string_valid(input_data, expected_result):
+        """ Test AllowEmptyString with different valid input (empty string ('') and not empty string). """
+        validator = AllowEmptyString(DecimalValidator())
+        result = validator.validate(input_data)
+
+        assert type(result) == type(expected_result)
+        assert result == expected_result
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data, expected_result',
+        [
+            ('', Decimal('3.1415')),
+            ('12.34', Decimal('12.34')),
+        ]
+    )
+    def test_allow_empty_string_with_default_valid(input_data, expected_result):
+        """ Test AllowEmptyString with a custom default value with different valid input (empty string ('') and not empty string). """
+        validator = AllowEmptyString(DecimalValidator(), default=Decimal('3.1415'))
+        result = validator.validate(input_data)
+
+        assert type(result) == type(expected_result)
+        assert result == expected_result
+
+    @staticmethod
+    def test_allow_empty_string_with_context_arguments():
+        """ Test that AllowEmptyString passes context arguments down to the wrapped validator. """
+        validator = AllowEmptyString(UnitTestContextValidator())
+        assert validator.validate('') is ''
+        assert validator.validate('unittest') == "unittest / {}"
+        assert validator.validate('unittest', foo=42) == "unittest / {'foo': 42}"
+
+    @staticmethod
+    def test_invalid_not_empty_string_value():
+        """ Test that AllowEmptyString correctly wraps a specified validator and leaves (most) exceptions unmodified. """
+        validator = AllowEmptyString(DecimalValidator())
+        with pytest.raises(ValidationError) as exception_info:
+            validator.validate('foobar')
+        assert exception_info.value.to_dict() == {'code': 'invalid_decimal'}
+
+    @staticmethod
+    def test_invalid_type_contains_empty_string():
+        """ Test that AllowEmptyString adds '' to the expected_types parameter if the wrapped validator raises an InvalidTypeError. """
+        validator = AllowEmptyString(DecimalValidator())
+        with pytest.raises(ValidationError) as exception_info:
+            validator.validate(123)
+        assert exception_info.value.to_dict() == {
+            'code': 'invalid_type',
+            'expected_types': ['', 'str'],
+        }
+
+    @staticmethod
+    def test_default_value_is_deepcopied():
+        """
+        Test that given default values are deepcopied. Otherwise using for example `default=[]` would always return a
+        reference to the *same* list, and modifying this list would result in unexpected behaviour.
+        """
+        # Note: An empty list as default value for an IntegerValidator doesn't make a lot of sense, but simplifies the test.
+        validator = AllowEmptyString(IntegerValidator(), default=[])
+        first_list = validator.validate('')
+        second_list = validator.validate('')
+        assert first_list == []
+        assert second_list == []
+
+        # The lists are equal (both are empty lists), but they must not be the *same* object, otherwise bad stuff will happen.
+        assert first_list is not second_list
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'validator',
+        [
+            # Non-sense types
+            '',
+            'banana',
+
+            # Validator class instead of instance (common mistake)
+            IntegerValidator,
+        ]
+    )
+    def test_invalid_validator_type(validator):
+        """ Test that AllowEmptyString raises an exception on construction if the wrapped validator has the wrong type. """
+        with pytest.raises(TypeError, match='AllowEmptyString requires a Validator instance'):
+            AllowEmptyString(validator)  # noqa

--- a/tests/validators/allow_empty_string_test.py
+++ b/tests/validators/allow_empty_string_test.py
@@ -68,13 +68,12 @@ class AllowEmptyStringTest:
     @staticmethod
     def test_invalid_type_contains_empty_string():
         """ Test that AllowEmptyString adds str to the expected_types parameter if the wrapped validator raises an InvalidTypeError. """
-        validator = AllowEmptyString(DecimalValidator())
+        validator = AllowEmptyString(IntegerValidator())
         with pytest.raises(ValidationError) as exception_info:
-            validator.validate(123)
-        print(exception_info.value.to_dict())
+            validator.validate('unittest')
         assert exception_info.value.to_dict() == {
             'code': 'invalid_type',
-            'expected_type': 'str',
+            'expected_types': ['int', 'str'],
         }
 
     @staticmethod


### PR DESCRIPTION
#87
New wrapper validator **AllowEmptyString** that allows the empty string as input. 
Usage: 

        validator = AllowEmptyString(BooleanValidator())
        validator.validate('')  # will return the string ''
    
        validator = AllowEmptyString(BooleanValidator(), default='no value given!')
        validator.validate('')  # will return the string "no value given"

Tests also added.