### PR TITLE
Update testing dependencies to fix test suite

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ where = src
 
 [options.extras_require]
 testing =
-    pytest ~= 7.1
-    pytest-cov ~= 3.0
-    coverage ~= 6.4
+    pytest ~= 7.2
+    pytest-cov
+    coverage ~= 6.5
     coverage-conditional-plugin ~= 0.5


### PR DESCRIPTION
Due to some minor version updates and version incompatibilities, the test suites are broken. This should fix it.