### PR TITLE
AnyOfValidator/EnumValidator: Set case-sensitive as default (#93)

### DIFF
--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -856,9 +856,13 @@ These values can potentially be of any type, although strings and integers are p
 The `AnyOfValidator` is defined with a simple list of allowed values and accepts only values that are part of this list.
 The values will be returned as defined in the list.
 
-By default, strings will be matched case-sensitively. To change this, set `case_insensitive=True`. In that case, the
-value will always be returned as it is defined in the list of allowed values (e.g. if the allowed values contain
-"Apple", then "APPLE" and "apple" will be valid input too, but in all cases "Apple" will be returned).
+By default, strings will be matched **case-insensitively**. To change this, set `case_sensitive=True`. The returned
+value will always be as defined in the list of allowed values (e.g. if the allowed values contain "Apple" and the
+validator is case-insensitive, then "APPLE" and "apple" will be valid input too, but in all cases "Apple" will be
+returned).
+
+**NOTE:** Prior to version 0.8.0, the validator was NOT case-insensitive by default. The old parameter `case_insensitive`
+still exists for compatibility, but is deprecated now and will be removed in a future version.
 
 The list of allowed values may contain mixed types (e.g. `['banana', 123, True, None]`). Also the allowed values can be
 specified with any iterable, not just as a list (e.g. as a set or tuple).
@@ -878,18 +882,19 @@ include the list of allowed values (as "allowed_values"), as long as this list i
 ```python
 from validataclass.validators import AnyOfValidator
 
-# Accept a specific list of strings
-validator = AnyOfValidator(['apple', 'banana', 'strawberry'])
-validator.validate('banana')      # will return 'banana'
-validator.validate('strawberry')  # will return 'strawberry'
-validator.validate('pineapple')   # will raise ValueNotAllowedError()
-validator.validate(1)             # will raise InvalidTypeError(expected_type='str')
-
-# Accept strings with case-insensitive matching
-validator = AnyOfValidator(['Apple', 'Banana', 'Strawberry'], case_insensitive=True)
+# Accept a specific list of strings (case-insensitive by default)
+validator = AnyOfValidator(['Apple', 'Banana', 'Strawberry'])
 validator.validate('apple')       # will return 'Apple'
 validator.validate('bAnAnA')      # will return 'Banana'
 validator.validate('STRAWBERRY')  # will return 'Strawberry'
+validator.validate('pineapple')   # will raise ValueNotAllowedError()
+validator.validate(1)             # will raise InvalidTypeError(expected_type='str')
+
+# Accept strings with case-sensitive matching
+validator = AnyOfValidator(['Apple', 'Banana', 'Strawberry'], case_sensitive=True)
+validator.validate('Banana')     # will return 'Banana'
+validator.validate('banana')     # will raise ValueNotAllowedError
+validator.validate('BANANA')     # will raise ValueNotAllowedError
 
 # Accept a list of values of mixed types
 validator = AnyOfValidator(['banana', 123, True, None])
@@ -916,7 +921,10 @@ The `EnumValidator` is an extended `AnyOfValidator` that uses `Enum` classes ins
 
 It accepts the **values** of the Enum and converts the input value to the according enum **member**.
 
-Strings will be matched case-sensitively by default. To change this, set `case_insensitive=True`.
+Strings will be matched **case-insensitively** by default. To change this, set `case_insensitive=True`.
+
+NOTE: Prior to version 0.8.0, the validator was NOT case-insensitive by default. The old parameter "case_insensitive"
+still exists for compatibility, but is deprecated now and will be removed in a future version.
 
 By default all values in the Enum are accepted as input. This can be optionally restricted by specifying the
 `allowed_values` parameter, which will override the list of allowed values. Values in this list that are not valid for
@@ -951,19 +959,19 @@ class ExampleIntegerEnum(Enum):
     BAR = 3
     BAZ = -20
 
-# Default: Accept all values of the ExampleStringEnum
+# Default: Accept all values of the ExampleStringEnum (case-insensitive)
 validator = EnumValidator(ExampleStringEnum)
 validator.validate('apple')       # will return ExampleStringEnum.APPLE
-validator.validate('banana')      # will return ExampleStringEnum.BANANA
-validator.validate('strawberry')  # will return ExampleStringEnum.STRAWBERRY
+validator.validate('BANANA')      # will return ExampleStringEnum.BANANA
+validator.validate('Strawberry')  # will return ExampleStringEnum.STRAWBERRY
 validator.validate('pineapple')   # will raise ValueNotAllowedError
 validator.validate(123)           # will raise InvalidTypeError(expected_type='str')
 
-# Accept all values of the ExampleStringEnum with case-insensitive string matching
-validator = EnumValidator(ExampleStringEnum, case_insensitive=True)
-validator.validate('Apple')       # will return ExampleStringEnum.APPLE
-validator.validate('bAnAnA')      # will return ExampleStringEnum.BANANA
-validator.validate('STRAWBERRY')  # will return ExampleStringEnum.STRAWBERRY
+# Accept all values of the ExampleStringEnum, but with case-sensitive matching
+validator = EnumValidator(ExampleStringEnum, case_sensitive=True)
+validator.validate('apple')       # will return ExampleStringEnum.APPLE
+validator.validate('Apple')       # will raise ValueNotAllowedError
+validator.validate('APPLE')       # will raise ValueNotAllowedError
 
 # Default: Accept all values of the ExampleIntegerEnum
 validator = EnumValidator(ExampleIntegerEnum)

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -15,7 +15,7 @@ __all__ = [
     'T_Enum',
 ]
 
-# Type variable for type hints in DataclassValidator
+# Type variable for type hints in EnumValidator
 T_Enum = TypeVar('T_Enum', bound=Enum)
 
 
@@ -36,7 +36,10 @@ class EnumValidator(Generic[T_Enum], AnyOfValidator):
     The types allowed for input data will be automatically determined from the allowed Enum values by default, unless
     explicitly specified with the parameter `allowed_types`.
 
-    By default, strings will be matched case-sensitively. To change this, set `case_insensitive=True`.
+    By default, strings will be matched *case-insensitively*. To change this, set `case_sensitive=True`.
+
+    NOTE: Prior to version 0.8.0, the validator was NOT case-insensitive by default. The old parameter "case_insensitive"
+    still exists for compatibility, but is deprecated now and will be removed in a future version.
 
     If the input value is not valid (but has the correct type), a ValueNotAllowedError (code='value_not_allowed') will
     be raised. This error will include the list of allowed values (as "allowed_values"), as long as this list is not
@@ -67,13 +70,16 @@ class EnumValidator(Generic[T_Enum], AnyOfValidator):
     # Enum class used to determine the list of allowed values
     enum_cls: Type[Enum]
 
+    # TODO: For version 1.0, remove the old parameter "case_insensitive" completely and set a real default value for the
+    #  new "case_sensitive" parameter. (See base AnyOfValidator.)
     def __init__(
         self,
         enum_cls: Type[Enum],
         *,
         allowed_values: Optional[Iterable[Any]] = None,
         allowed_types: Optional[Union[type, Iterable[type]]] = None,
-        case_insensitive: bool = False,
+        case_sensitive: Optional[bool] = None,
+        case_insensitive: Optional[bool] = None,
     ):
         """
         Create a EnumValidator for a specified Enum class, optionally with a restricted list of allowed values.
@@ -82,7 +88,8 @@ class EnumValidator(Generic[T_Enum], AnyOfValidator):
             enum_cls: Enum class to use for validation (required)
             allowed_values: List (or iterable) of values from the Enum that are accepted (default: None, all Enum values allowed)
             allowed_types: List (or iterable) of types allowed for input data (default: None, autodetermine types from enum values)
-            case_insensitive: If set, strings will be matched case-insensitively (default: False)
+            case_sensitive: If set, strings will be matched case-sensitively (default: True)
+            case_insensitive: DEPRECATED. Validator is case-insensitive by default, use case_sensitive to change this.
         """
         # Ensure parameter is an Enum class
         if not isinstance(enum_cls, EnumMeta):
@@ -105,6 +112,7 @@ class EnumValidator(Generic[T_Enum], AnyOfValidator):
         super().__init__(
             allowed_values=any_of_values,
             allowed_types=allowed_types,
+            case_sensitive=case_sensitive,
             case_insensitive=case_insensitive,
         )
 


### PR DESCRIPTION
This PR implements the change described in https://github.com/binary-butterfly/validataclass/issues/93.

Both the AnyOfValidator and EnumValidator are now case-insensitive by default (when using strings).

**This is a smaller breaking change**, which practically shouldn't affect anyone negatively.

The old parameter `case_insensitive` was **deprecated** and replaced with a new parameter `case_sensitive` (with the opposite meaning, of course). The old parameter is still supported for compatibility, but issues a DeprecationWarning and will be removed in a future version.