### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 /.tox_docker
 /.eggs
 /.coverage
+/.coverage.*
 /.pytest_cache
 /build
 /dist

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # Settings
-# NOTE: The multi-python image is a fork of fkrull/multi-python, which as of now has not been updated for Python 3.10 yet
-DOCKER_MULTI_PYTHON_IMAGE = gnufede/multi-python:focal
+DOCKER_MULTI_PYTHON_IMAGE = acidrain/multi-python:latest
 DOCKER_USER = "$(shell id -u):$(shell id -g)"
 
 # Default target
@@ -38,7 +37,7 @@ venv-tox:
 # Only run pytest
 .PHONY: test
 test:
-	tox -e 'clean,py{310,39,38,37},report'
+	tox -e 'clean,py{311,310,39,38,37},report'
 
 # Only run flake8 linter
 .PHONY: flake8
@@ -62,7 +61,9 @@ docker-tox:
 		tox --workdir .tox_docker $(TOX_ARGS)
 
 # Run partial tox test suites in Docker
-.PHONY: docker-tox-py310 docker-tox-py39 docker-tox-py38 docker-tox-py37
+.PHONY: docker-tox-py311 docker-tox-py310 docker-tox-py39 docker-tox-py38 docker-tox-py37
+docker-tox-py311: TOX_ARGS="-e clean,py311,py311-report"
+docker-tox-py311: docker-tox
 docker-tox-py310: TOX_ARGS="-e clean,py310,py310-report"
 docker-tox-py310: docker-tox
 docker-tox-py39: TOX_ARGS="-e clean,py39,py39-report"
@@ -79,6 +80,7 @@ docker-tox-all:
 	make docker-tox-py38
 	make docker-tox-py39
 	make docker-tox-py310
+	make docker-tox-py311
 
 # Pull the latest image of the multi-python Docker image
 .PHONY: docker-pull
@@ -91,7 +93,7 @@ docker-pull:
 
 .PHONY: clean
 clean:
-	rm -rf .coverage .pytest_cache reports src/validataclass/_version.py
+	rm -rf .coverage .pytest_cache reports src/validataclass/_version.py .tox .tox_docker .eggs src/*.egg-info venv
 
 .PHONY: clean-dist
 clean-dist:
@@ -99,4 +101,3 @@ clean-dist:
 
 .PHONY: clean-all
 clean-all: clean clean-dist
-	rm -rf .tox .tox_docker .eggs src/*.egg-info venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities

--- a/src/validataclass/dataclasses/defaults.py
+++ b/src/validataclass/dataclasses/defaults.py
@@ -40,6 +40,9 @@ class Default:
             return self.value == other.value
         return NotImplemented
 
+    def __hash__(self):
+        return hash(self.value)
+
     def get_value(self) -> Any:
         return deepcopy(self.value)
 
@@ -74,6 +77,9 @@ class DefaultFactory(Default):
         if isinstance(self, type(other)):
             return isinstance(other, DefaultFactory) and self.factory == other.factory
         return NotImplemented
+
+    def __hash__(self):
+        return hash(self.factory)
 
     def get_value(self) -> Any:
         return self.factory()
@@ -126,6 +132,10 @@ class _NoDefault(Default):
     def __eq__(self, other):
         # Nothing is equal to NoDefault except itself
         return type(self) is type(other)
+
+    def __hash__(self):
+        # Use default implementation
+        return object.__hash__(self)
 
     def get_value(self) -> NoReturn:
         raise ValueError('No default value specified!')

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -39,8 +39,8 @@ class UnsetValueType:
     def __bool__(self):
         return False
 
-    def __eq__(self, other):
-        return other is self
+    # Don't define __eq__ because the default implementation is fine (identity check), and because we would then have to
+    # implement __hash__ as well, otherwise UnsetValue would be considered mutable by @dataclass.
 
 
 # Create sentinel object and redefine __new__ so that the object cannot be cloned

--- a/tests/dataclasses/defaults_test.py
+++ b/tests/dataclasses/defaults_test.py
@@ -87,6 +87,12 @@ class DefaultTest:
         assert first != second
         assert second != first
 
+    @staticmethod
+    @pytest.mark.parametrize('value', [None, 0, 42, 'banana'])
+    def test_default_hashable(value):
+        """ Test hashability (__hash__) of Default objects. """
+        assert hash(Default(value)) == hash(value)
+
 
 class DefaultFactoryTest:
     """ Tests for the DefaultFactory class. """
@@ -167,6 +173,11 @@ class DefaultFactoryTest:
         assert first != second
         assert second != first
 
+    @staticmethod
+    def test_default_factory_hashable():
+        """ Test hashability (__hash__) of DefaultFactory objects. """
+        assert hash(DefaultFactory(list)) == hash(list)
+
 
 class DefaultUnsetTest:
     """ Tests for the DefaultUnset sentinel object. """
@@ -237,6 +248,11 @@ class NoDefaultTest:
         """ Test non-equality between NoDefault and other objects. """
         assert NoDefault != other
         assert other != NoDefault
+
+    @staticmethod
+    def test_no_default_hashable():
+        """ Test that NoDefault is hashable (i.e. implements __hash__). """
+        assert hash(NoDefault) == object.__hash__(NoDefault)
 
     @staticmethod
     def test_no_default_call():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py{310,39,38,37},flake8,report
+envlist = clean,py{311,310,39,38,37},flake8,report
 skip_missing_interpreters = true
 isolated_build = true
 
@@ -36,7 +36,7 @@ commands =
 
 # These environments basically are an alias for "report" that allow to specify the python version used for coverage.
 # tox 4 apparently will have a "labels" option that can be used to define aliases, but that version is not released yet.
-[testenv:py{310,39,38,37}-report]
+[testenv:py{311,310,39,38,37}-report]
 skip_install = true
 deps = {[testenv:report]deps}
 commands = {[testenv:report]commands}


### PR DESCRIPTION
This PR adds official support for Python 3.11 to the library.

Python 3.11 was added as a target for the test environments (both tox for local testing and GitHub actions).

There was one incompatibility that needed to be fixed: In Python 3.11 the `@dataclass` implementation was changed to check for the immutability of default values by checking if they are hashable (i.e. if their classes have an implementation for `__hash__`). This wasn't true for `UnsetValue`, so it couldn't be used as a default value anymore.