### PR TITLE
Update local test environment for tox 4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run unit tests with tox
         # Run tox using the version of Python in `PATH`
-        run: tox -e clean,py,flake8,report -- --junit-xml=reports/pytest_${{ matrix.python-version }}.xml
+        run: tox run -e clean,py,flake8,report -- --junit-xml=reports/pytest_${{ matrix.python-version }}.xml
 
       - name: Upload test result artifacts
         uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -27,22 +27,22 @@ build:
 # Run complete tox suite
 .PHONY: tox
 tox:
-	tox
+	tox run
 
 # Run tox in venv (needs to be installed with `make venv` first)
 .PHONY: venv-tox
 venv-tox:
-	. venv/bin/activate && tox
+	. venv/bin/activate && tox run
 
 # Only run pytest
 .PHONY: test
 test:
-	tox -e 'clean,py{311,310,39,38,37},report'
+	tox run --skip-env flake8
 
 # Only run flake8 linter
 .PHONY: flake8
 flake8:
-	tox -e flake8
+	tox run -e flake8
 
 # Open HTML coverage report in browser
 .PHONY: open-coverage
@@ -58,7 +58,7 @@ docker-tox:
 		--workdir /code \
 		--env HOME=/tmp/home \
 		$(DOCKER_MULTI_PYTHON_IMAGE) \
-		tox --workdir .tox_docker $(TOX_ARGS)
+		tox run --workdir .tox_docker $(TOX_ARGS)
 
 # Run partial tox test suites in Docker
 .PHONY: docker-tox-py311 docker-tox-py310 docker-tox-py39 docker-tox-py38 docker-tox-py37

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 4.5.1
 envlist = clean,py{311,310,39,38,37},flake8,report
 skip_missing_interpreters = true
 isolated_build = true
@@ -25,7 +26,7 @@ skip_install = true
 deps = {[testenv:report]deps}
 commands = coverage erase
 
-[testenv:report]
+[testenv:report,py{311,310,39,38,37}-report]
 skip_install = true
 deps =
     coverage
@@ -33,10 +34,3 @@ deps =
 commands =
     coverage html
     coverage report --fail-under=100
-
-# These environments basically are an alias for "report" that allow to specify the python version used for coverage.
-# tox 4 apparently will have a "labels" option that can be used to define aliases, but that version is not released yet.
-[testenv:py{311,310,39,38,37}-report]
-skip_install = true
-deps = {[testenv:report]deps}
-commands = {[testenv:report]commands}


### PR DESCRIPTION
The [tox](https://tox.wiki/) project had a [major update](https://tox.wiki/en/latest/upgrading.html) with some API changes.

This PR adjusts the local test environment (and a small thing in the GitHub actions) to use the new tox API, and simplifies the tox config a bit.