### PR TITLE
Fix style of type comparisons in some unit tests

### DIFF
--- a/tests/validators/allow_empty_string_test.py
+++ b/tests/validators/allow_empty_string_test.py
@@ -30,7 +30,7 @@ class AllowEmptyStringTest:
         validator = AllowEmptyString(DecimalValidator())
         result = validator.validate(input_data)
 
-        assert type(result) == type(expected_result)
+        assert isinstance(result, type(expected_result))
         assert result == expected_result
 
     @staticmethod
@@ -46,7 +46,7 @@ class AllowEmptyStringTest:
         validator = AllowEmptyString(DecimalValidator(), default=Decimal('3.1415'))
         result = validator.validate(input_data)
 
-        assert type(result) == type(expected_result)
+        assert isinstance(result, type(expected_result))
         assert result == expected_result
 
     @staticmethod

--- a/tests/validators/allow_empty_string_test.py
+++ b/tests/validators/allow_empty_string_test.py
@@ -30,7 +30,7 @@ class AllowEmptyStringTest:
         validator = AllowEmptyString(DecimalValidator())
         result = validator.validate(input_data)
 
-        assert isinstance(result, type(expected_result))
+        assert type(result) is type(expected_result)
         assert result == expected_result
 
     @staticmethod
@@ -46,7 +46,7 @@ class AllowEmptyStringTest:
         validator = AllowEmptyString(DecimalValidator(), default=Decimal('3.1415'))
         result = validator.validate(input_data)
 
-        assert isinstance(result, type(expected_result))
+        assert type(result) is type(expected_result)
         assert result == expected_result
 
     @staticmethod

--- a/tests/validators/none_to_unset_value_test.py
+++ b/tests/validators/none_to_unset_value_test.py
@@ -31,7 +31,7 @@ class NoneToUnsetValueTest:
         validator = NoneToUnsetValue(DecimalValidator())
         result = validator.validate(input_data)
 
-        assert type(result) == type(expected_result)
+        assert isinstance(result, type(expected_result))
         assert result == expected_result
 
     @staticmethod

--- a/tests/validators/none_to_unset_value_test.py
+++ b/tests/validators/none_to_unset_value_test.py
@@ -31,7 +31,7 @@ class NoneToUnsetValueTest:
         validator = NoneToUnsetValue(DecimalValidator())
         result = validator.validate(input_data)
 
-        assert isinstance(result, type(expected_result))
+        assert type(result) is type(expected_result)
         assert result == expected_result
 
     @staticmethod

--- a/tests/validators/noneable_test.py
+++ b/tests/validators/noneable_test.py
@@ -31,7 +31,7 @@ class NoneableTest:
         validator = Noneable(DecimalValidator())
         result = validator.validate(input_data)
 
-        assert isinstance(result, type(expected_result))
+        assert type(result) is type(expected_result)
         assert result == expected_result
 
     @staticmethod
@@ -47,7 +47,7 @@ class NoneableTest:
         validator = Noneable(DecimalValidator(), default=Decimal('3.1415'))
         result = validator.validate(input_data)
 
-        assert isinstance(result, type(expected_result))
+        assert type(result) is type(expected_result)
         assert result == expected_result
 
     @staticmethod

--- a/tests/validators/noneable_test.py
+++ b/tests/validators/noneable_test.py
@@ -31,7 +31,7 @@ class NoneableTest:
         validator = Noneable(DecimalValidator())
         result = validator.validate(input_data)
 
-        assert type(result) == type(expected_result)
+        assert isinstance(result, type(expected_result))
         assert result == expected_result
 
     @staticmethod
@@ -47,7 +47,7 @@ class NoneableTest:
         validator = Noneable(DecimalValidator(), default=Decimal('3.1415'))
         result = validator.validate(input_data)
 
-        assert type(result) == type(expected_result)
+        assert isinstance(result, type(expected_result))
         assert result == expected_result
 
     @staticmethod


### PR DESCRIPTION
While I was setting up the dev environment, I ran the tests as described in the readme, and got some error messages from flake8:

```
tests/validators/allow_empty_string_test.py:33:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/validators/allow_empty_string_test.py:49:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/validators/none_to_unset_value_test.py:34:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/validators/noneable_test.py:34:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/validators/noneable_test.py:50:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```

I fixed the style according to these messages, now the tests run without flake8 complaining again :)