### PR TITLE
Add official support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,9 @@ docker-tox:
 		tox run --workdir .tox_docker $(TOX_ARGS)
 
 # Run partial tox test suites in Docker
-.PHONY: docker-tox-py311 docker-tox-py310 docker-tox-py39 docker-tox-py38 docker-tox-py37
+.PHONY: docker-tox-py312 docker-tox-py311 docker-tox-py310 docker-tox-py39 docker-tox-py38 docker-tox-py37
+docker-tox-py312: TOX_ARGS="-e clean,py312,py312-report"
+docker-tox-py312: docker-tox
 docker-tox-py311: TOX_ARGS="-e clean,py311,py311-report"
 docker-tox-py311: docker-tox
 docker-tox-py310: TOX_ARGS="-e clean,py310,py310-report"
@@ -81,6 +83,7 @@ docker-tox-all:
 	make docker-tox-py39
 	make docker-tox-py310
 	make docker-tox-py311
+	make docker-tox-py312
 
 # Pull the latest image of the multi-python Docker image
 .PHONY: docker-pull

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.5.1
-envlist = clean,py{311,310,39,38,37},flake8,report
+envlist = clean,py{312,311,310,39,38,37},flake8,report
 skip_missing_interpreters = true
 isolated_build = true
 
@@ -26,7 +26,7 @@ skip_install = true
 deps = {[testenv:report]deps}
 commands = coverage erase
 
-[testenv:report,py{311,310,39,38,37}-report]
+[testenv:report,py{312,311,310,39,38,37}-report]
 skip_install = true
 deps =
     coverage


### PR DESCRIPTION
This PR adds Python 3.12 to the test environments, therefore adding official support for Python 3.12.

No further changes for Python 3.12 compatibility were needed.