### PR TITLE
Integrate mypy into development process (part of #116)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,7 +16,8 @@ show_missing = True
 skip_empty = True
 skip_covered = True
 exclude_lines =
-    pragma: nocover
+    pragma: no ?cover
+    @abstractmethod
     @overload
     if TYPE_CHECKING:
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -18,6 +18,7 @@ skip_covered = True
 exclude_lines =
     pragma: nocover
     @overload
+    if TYPE_CHECKING:
 
 [html]
 directory = reports/coverage_html/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run unit tests with tox
         # Run tox using the version of Python in `PATH`
-        run: tox run -e clean,py,flake8,report -- --junit-xml=reports/pytest_${{ matrix.python-version }}.xml
+        run: tox run -e clean,py,report,flake8,mypy -- --junit-xml=reports/pytest_${{ matrix.python-version }}.xml
 
       - name: Upload test result artifacts
         uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build:
 # Test suite
 # ----------
 
-# Run complete tox suite
+# Run complete tox suite with local Python interpreter
 .PHONY: tox
 tox:
 	tox run
@@ -37,7 +37,7 @@ venv-tox:
 # Only run pytest
 .PHONY: test
 test:
-	tox run --skip-env flake8,mypy
+	tox run -e clean,py,report
 
 # Only run flake8 linter
 .PHONY: flake8
@@ -67,25 +67,25 @@ docker-tox:
 
 # Run partial tox test suites in Docker
 .PHONY: docker-tox-py312 docker-tox-py311 docker-tox-py310 docker-tox-py39 docker-tox-py38
-docker-tox-py312: TOX_ARGS="-e clean,py312,py312-report"
-docker-tox-py312: docker-tox
-docker-tox-py311: TOX_ARGS="-e clean,py311,py311-report"
-docker-tox-py311: docker-tox
-docker-tox-py310: TOX_ARGS="-e clean,py310,py310-report"
-docker-tox-py310: docker-tox
-docker-tox-py39: TOX_ARGS="-e clean,py39,py39-report"
-docker-tox-py39: docker-tox
-docker-tox-py38: TOX_ARGS="-e clean,py38,py38-report"
-docker-tox-py38: docker-tox
+docker-test-py312: TOX_ARGS="-e clean,py312,py312-report"
+docker-test-py312: docker-tox
+docker-test-py311: TOX_ARGS="-e clean,py311,py311-report"
+docker-test-py311: docker-tox
+docker-test-py310: TOX_ARGS="-e clean,py310,py310-report"
+docker-test-py310: docker-tox
+docker-test-py39: TOX_ARGS="-e clean,py39,py39-report"
+docker-test-py39: docker-tox
+docker-test-py38: TOX_ARGS="-e clean,py38,py38-report"
+docker-test-py38: docker-tox
 
 # Run all tox test suites, but separately to check code coverage individually
 .PHONY: docker-tox-all
-docker-tox-all:
-	make docker-tox-py38
-	make docker-tox-py39
-	make docker-tox-py310
-	make docker-tox-py311
-	make docker-tox-py312
+docker-test-all:
+	make docker-test-py38
+	make docker-test-py39
+	make docker-test-py310
+	make docker-test-py311
+	make docker-test-py312
 
 # Run mypy using all different (or specific) Python versions in Docker
 .PHONY: docker-mypy-all docker-mypy-py312 docker-mypy-py311 docker-mypy-py310 docker-mypy-py39 docker-mypy-py38

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,17 @@ venv-tox:
 # Only run pytest
 .PHONY: test
 test:
-	tox run --skip-env flake8
+	tox run --skip-env flake8,mypy
 
 # Only run flake8 linter
 .PHONY: flake8
 flake8:
 	tox run -e flake8
+
+# Only run mypy (via tox; you can also just run "mypy" directly)
+.PHONY: mypy
+mypy:
+	tox run -e mypy
 
 # Open HTML coverage report in browser
 .PHONY: open-coverage
@@ -81,6 +86,21 @@ docker-tox-all:
 	make docker-tox-py310
 	make docker-tox-py311
 	make docker-tox-py312
+
+# Run mypy using all different (or specific) Python versions in Docker
+.PHONY: docker-mypy-all docker-mypy-py312 docker-mypy-py311 docker-mypy-py310 docker-mypy-py39 docker-mypy-py38
+docker-mypy-all: TOX_ARGS="-e py312-mypy,py311-mypy,py310-mypy,py39-mypy,py38-mypy,py37-mypy"
+docker-mypy-all: docker-tox
+docker-mypy-py312: TOX_ARGS="-e py312-mypy"
+docker-mypy-py312: docker-tox
+docker-mypy-py311: TOX_ARGS="-e py311-mypy"
+docker-mypy-py311: docker-tox
+docker-mypy-py310: TOX_ARGS="-e py310-mypy"
+docker-mypy-py310: docker-tox
+docker-mypy-py39: TOX_ARGS="-e py39-mypy"
+docker-mypy-py39: docker-tox
+docker-mypy-py38: TOX_ARGS="-e py38-mypy"
+docker-mypy-py38: docker-tox
 
 # Pull the latest image of the multi-python Docker image
 .PHONY: docker-pull

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,9 @@ version_scheme = "post-release"
 
 [tool.mypy]
 files = "src/"
+
+# Enable strict type checking
+strict = true
+
+# Ignore errors like `Module "validataclass.exceptions" does not explicitly export attribute "..."`
+no_implicit_reexport = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/validataclass/_version.py"
 version_scheme = "post-release"
+
+[tool.mypy]
+files = "src/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,3 +44,5 @@ testing =
     pytest-cov
     coverage ~= 6.5
     coverage-conditional-plugin ~= 0.5
+    flake8 ~= 7.0
+    mypy ~= 1.9

--- a/src/validataclass/dataclasses/defaults.py
+++ b/src/validataclass/dataclasses/defaults.py
@@ -125,7 +125,7 @@ class _DefaultUnset(Default):
 
 # Create sentinel object DefaultUnset, redefine __new__ to always return the same instance, and delete temporary class
 DefaultUnset = _DefaultUnset()
-_DefaultUnset.__new__ = lambda cls: DefaultUnset
+_DefaultUnset.__new__ = lambda cls: DefaultUnset  # type: ignore
 del _DefaultUnset
 
 
@@ -162,5 +162,5 @@ class _NoDefault(Default):
 
 # Create sentinel object NoDefault, redefine __new__ to always return the same instance, and delete temporary class
 NoDefault = _NoDefault()
-_NoDefault.__new__ = lambda cls: NoDefault
+_NoDefault.__new__ = lambda cls: NoDefault  # type: ignore
 del _NoDefault

--- a/src/validataclass/dataclasses/defaults.py
+++ b/src/validataclass/dataclasses/defaults.py
@@ -7,6 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 from copy import copy, deepcopy
 from typing import Any, Callable, NoReturn
 
+from typing_extensions import Self
+
 from validataclass.helpers import UnsetValue, UnsetValueType
 
 __all__ = [
@@ -33,15 +35,15 @@ class Default:
     def __init__(self, value: Any = None):
         self.value = deepcopy(value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{type(self).__name__}({self.value!r})'
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if isinstance(self, type(other)):
-            return self.value == other.value
+            return bool(self.value == other.value)
         return NotImplemented
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.value)
 
     def get_value(self) -> Any:
@@ -74,21 +76,21 @@ class DefaultFactory(Default):
     DefaultFactory(lambda: date.today())
     ```
     """
-    factory: Callable
+    factory: Callable[[], Any]
 
-    def __init__(self, factory: Callable):
+    def __init__(self, factory: Callable[[], Any]):
         super().__init__()
         self.factory = factory
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{type(self).__name__}({self.factory!r})'
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if isinstance(self, type(other)):
-            return isinstance(other, DefaultFactory) and self.factory == other.factory
+            return isinstance(other, DefaultFactory) and bool(self.factory == other.factory)
         return NotImplemented
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.factory)
 
     def get_value(self) -> Any:
@@ -104,10 +106,10 @@ class _DefaultUnset(Default):
     Class for creating the sentinel object `DefaultUnset`, which is a shortcut for `Default(UnsetValue)`.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(UnsetValue)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'DefaultUnset'
 
     def get_value(self) -> UnsetValueType:
@@ -117,7 +119,7 @@ class _DefaultUnset(Default):
         return False
 
     # For convenience: Allow DefaultUnset to be used as `DefaultUnset()`, returning the sentinel itself.
-    def __call__(self):
+    def __call__(self) -> Self:
         return self
 
 
@@ -136,17 +138,17 @@ class _NoDefault(Default):
     A validataclass field with `NoDefault` is equivalent to a validataclass field without specified default.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'NoDefault'
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         # Nothing is equal to NoDefault except itself
         return type(self) is type(other)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # Use default implementation
         return object.__hash__(self)
 
@@ -154,7 +156,7 @@ class _NoDefault(Default):
         raise ValueError('No default value specified!')
 
     # For convenience: Allow NoDefault to be used as `NoDefault()`, returning the sentinel itself.
-    def __call__(self):
+    def __call__(self) -> Self:
         return self
 
 

--- a/src/validataclass/dataclasses/validataclass.py
+++ b/src/validataclass/dataclasses/validataclass.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 import dataclasses
 import sys
 from collections import namedtuple
-from typing import Callable, Dict, Optional, Type, TypeVar, Union, overload
+from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, Union, overload
 
 from typing_extensions import dataclass_transform
 
@@ -31,7 +31,7 @@ def validataclass(cls: Type[_T]) -> Type[_T]:
 
 
 @overload
-def validataclass(cls: None = None, /, **kwargs) -> Callable[[Type[_T]], Type[_T]]:
+def validataclass(cls: None = None, /, **kwargs: Any) -> Callable[[Type[_T]], Type[_T]]:
     ...
 
 
@@ -42,7 +42,7 @@ def validataclass(cls: None = None, /, **kwargs) -> Callable[[Type[_T]], Type[_T
 def validataclass(
     cls: Optional[Type[_T]] = None,
     /,
-    **kwargs,
+    **kwargs: Any,
 ) -> Union[Type[_T], Callable[[Type[_T]], Type[_T]]]:
     """
     Decorator that turns a normal class into a `DataclassValidator`-compatible dataclass.
@@ -103,7 +103,7 @@ def validataclass(
     return decorator if cls is None else decorator(cls)
 
 
-def _prepare_dataclass_metadata(cls) -> None:
+def _prepare_dataclass_metadata(cls: Type[_T]) -> None:
     """
     Prepares a soon-to-be dataclass (before it is decorated with `@dataclass`) to be usable with `DataclassValidator`
     by checking it for `Validator` objects and setting dataclass metadata.
@@ -151,7 +151,7 @@ def _prepare_dataclass_metadata(cls) -> None:
         # If the field already exists in a superclass, the validator and/or default defined in this class will override
         # those of the superclass. E.g. setting a default will override the default, but leave the validator intact.
         if name in existing_validator_fields:
-            existing_field = existing_validator_fields.get(name)
+            existing_field = existing_validator_fields[name]
             if field_validator is None:
                 field_validator = existing_field.validator
             if field_default is None:
@@ -168,7 +168,7 @@ def _prepare_dataclass_metadata(cls) -> None:
         setattr(cls, name, validataclass_field(validator=field_validator, default=field_default, _name=name))
 
 
-def _get_existing_validator_fields(cls) -> Dict[str, _ValidatorField]:
+def _get_existing_validator_fields(cls: Type[_T]) -> Dict[str, _ValidatorField]:
     """
     Returns a dictionary containing all fields (as `_ValidatorField` objects) of an existing validataclass that have a
     validator set in their metadata, or an empty dictionary if the class is not a dataclass (yet).
@@ -196,7 +196,7 @@ def _get_existing_validator_fields(cls) -> Dict[str, _ValidatorField]:
     return validator_fields
 
 
-def _parse_validator_tuple(args: Union[tuple, None, Validator, Default]) -> _ValidatorField:
+def _parse_validator_tuple(args: Union[Tuple[Any, ...], Validator, Default, None]) -> _ValidatorField:
     """
     Parses field arguments (the value of a field in a dataclass that has not been parsed by `@dataclass` yet) to a
     tuple of a Validator and a Default object.

--- a/src/validataclass/dataclasses/validataclass_field.py
+++ b/src/validataclass/dataclasses/validataclass_field.py
@@ -6,7 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 import dataclasses
 import sys
-from typing import Any, NoReturn, Optional
+from typing import Any, Dict, NoReturn, Optional
 
 from validataclass.validators import Validator
 from .defaults import Default, NoDefault
@@ -20,10 +20,10 @@ def validataclass_field(
     validator: Validator,
     default: Any = NoDefault,
     *,
-    metadata: Optional[dict] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     _name: Optional[str] = None,  # noqa (undocumented parameter, only used internally)
-    **kwargs
-):
+    **kwargs: Any,
+) -> Any:
     """
     Defines a dataclass field compatible with DataclassValidator.
 
@@ -84,7 +84,7 @@ def validataclass_field(
     return dataclasses.field(metadata=metadata, **kwargs)
 
 
-def _raise_field_required(name: str) -> NoReturn:  # pragma: ignore-py-gte-310
+def _raise_field_required(name: Optional[str]) -> NoReturn:  # pragma: ignore-py-gte-310
     """
     Raises a TypeError exception. Used for required fields (only in Python 3.9 or lower where the kw_only option is not
     supported yet).

--- a/src/validataclass/dataclasses/validataclass_mixin.py
+++ b/src/validataclass/dataclasses/validataclass_mixin.py
@@ -6,7 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 import dataclasses
 import warnings
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from typing_extensions import Self
 
@@ -39,7 +39,10 @@ class ValidataclassMixin:
         Parameters:
             `keep_unset_values`: If true, keep fields with value `UnsetValue` in the dictionary (default: False)
         """
-        data = dataclasses.asdict(self)  # noqa
+        # Technically, there is no guarantee that this class is used as a mixin in an actual dataclass.
+        # However, if that's not the case, calling to_dict() doesn't make sense and will just fail with an exception.
+        # For all intents and purposes, we can safely assume that `self` is a dataclass instance.
+        data = cast(Dict[str, Any], dataclasses.asdict(self))  # type: ignore[call-overload]  # noqa
 
         # Filter out all UnsetValues (unless said otherwise)
         if not keep_unset_values:

--- a/src/validataclass/dataclasses/validataclass_mixin.py
+++ b/src/validataclass/dataclasses/validataclass_mixin.py
@@ -6,6 +6,9 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 import dataclasses
 import warnings
+from typing import Any, Dict
+
+from typing_extensions import Self
 
 from validataclass.helpers import UnsetValue
 
@@ -27,7 +30,7 @@ class ValidataclassMixin:
     ```
     """
 
-    def to_dict(self, *, keep_unset_values: bool = False) -> dict:
+    def to_dict(self, *, keep_unset_values: bool = False) -> Dict[str, Any]:
         """
         Returns the data of the object as a dictionary (recursively resolving inner dataclasses as well).
 
@@ -45,7 +48,7 @@ class ValidataclassMixin:
         return data
 
     @classmethod
-    def create_with_defaults(cls, **kwargs):
+    def create_with_defaults(cls, **kwargs: Any) -> Self:
         """
         (Deprecated.)
 

--- a/src/validataclass/exceptions/base_exceptions.py
+++ b/src/validataclass/exceptions/base_exceptions.py
@@ -4,7 +4,7 @@ Copyright (c) 2024, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 __all__ = [
     'ValidationError',
@@ -29,20 +29,20 @@ class ValidationError(Exception):
     """
     code: str = 'unknown_error'
     reason: Optional[str] = None
-    extra_data: Optional[dict] = None
+    extra_data: Optional[Dict[str, Any]] = None
 
-    def __init__(self, *, code: Optional[str] = None, reason: Optional[str] = None, **kwargs):
+    def __init__(self, *, code: Optional[str] = None, reason: Optional[str] = None, **kwargs: Any):
         if code is not None:
             self.code = code
         if reason is not None:
             self.reason = reason
         self.extra_data = {key: value for key, value in kwargs.items() if value is not None}
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         params_string = ', '.join(f'{key}={value}' for key, value in self._get_repr_dict().items() if value is not None)
         return f'{type(self).__name__}({params_string})'
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__repr__()
 
     def _get_repr_dict(self) -> Dict[str, str]:
@@ -58,7 +58,7 @@ class ValidationError(Exception):
             key: repr(value) for key, value in self.to_dict().items() if value is not None
         }
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> Dict[str, Any]:
         """
         Generates a dictionary containing error information, suitable as response to the user.
         May be overridden by subclasses to extend the dictionary.

--- a/src/validataclass/exceptions/common_exceptions.py
+++ b/src/validataclass/exceptions/common_exceptions.py
@@ -4,7 +4,7 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import List, Union
+from typing import Any, Dict, List, Union
 
 from .base_exceptions import ValidationError
 
@@ -47,16 +47,16 @@ class InvalidTypeError(ValidationError):
     code = 'invalid_type'
     expected_types: List[str]
 
-    def __init__(self, *, expected_types: Union[type, str, List[Union[type, str]]], **kwargs):
+    def __init__(self, *, expected_types: Union[type, str, List[Union[type, str]]], **kwargs: Any):
         super().__init__(**kwargs)
 
-        if type(expected_types) is not list:
+        if not isinstance(expected_types, list):
             expected_types = [expected_types]
         self.expected_types = [self._type_to_string(t) for t in expected_types]
 
     @staticmethod
     def _type_to_string(_type: Union[type, str]) -> str:
-        type_str = _type if type(_type) is str else _type.__name__
+        type_str = _type if isinstance(_type, str) else _type.__name__
         if type_str == 'NoneType':
             return 'none'
         return type_str
@@ -69,7 +69,7 @@ class InvalidTypeError(ValidationError):
         if new_type not in self.expected_types:
             self.expected_types.append(new_type)
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         base_dict = super().to_dict()
         self.expected_types.sort()
         if len(self.expected_types) == 1:

--- a/src/validataclass/exceptions/dataclass_exceptions.py
+++ b/src/validataclass/exceptions/dataclass_exceptions.py
@@ -4,9 +4,9 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'DataclassPostValidationError',
@@ -60,7 +60,7 @@ class DataclassPostValidationError(ValidationError):
         *,
         error: Optional[ValidationError] = None,
         field_errors: Optional[Dict[str, ValidationError]] = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
 
@@ -84,7 +84,7 @@ class DataclassPostValidationError(ValidationError):
 
         return base_dict
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         base_dict = super().to_dict()
 
         # Convert inner errors to dicts recursively

--- a/src/validataclass/exceptions/datetime_exceptions.py
+++ b/src/validataclass/exceptions/datetime_exceptions.py
@@ -4,7 +4,9 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from validataclass.exceptions import ValidationError
+from typing import Any
+
+from .base_exceptions import ValidationError
 
 __all__ = [
     'InvalidDateError',
@@ -23,7 +25,7 @@ class InvalidDateError(ValidationError):
     """
     code = 'invalid_date'
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any):
         super().__init__(date_format='YYYY-MM-DD', **kwargs)
 
 
@@ -37,7 +39,7 @@ class InvalidTimeError(ValidationError):
     """
     code = 'invalid_time'
 
-    def __init__(self, *, time_format_str: str, **kwargs):
+    def __init__(self, *, time_format_str: str, **kwargs: Any):
         super().__init__(time_format=time_format_str, **kwargs)
 
 
@@ -58,7 +60,7 @@ class InvalidDateTimeError(ValidationError):
     """
     code = 'invalid_datetime'
 
-    def __init__(self, *, datetime_format_str: str, **kwargs):
+    def __init__(self, *, datetime_format_str: str, **kwargs: Any):
         super().__init__(datetime_format=datetime_format_str, **kwargs)
 
 

--- a/src/validataclass/exceptions/dict_exceptions.py
+++ b/src/validataclass/exceptions/dict_exceptions.py
@@ -4,9 +4,9 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Dict
+from typing import Any, Dict
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'DictFieldsValidationError',
@@ -28,7 +28,7 @@ class DictFieldsValidationError(ValidationError):
     code = 'field_errors'
     field_errors: Dict[str, ValidationError]
 
-    def __init__(self, *, field_errors: Dict[str, ValidationError], **kwargs):
+    def __init__(self, *, field_errors: Dict[str, ValidationError], **kwargs: Any):
         super().__init__(**kwargs)
         assert all(isinstance(error, ValidationError) for error in field_errors.values())
         self.field_errors = field_errors
@@ -40,7 +40,7 @@ class DictFieldsValidationError(ValidationError):
             'field_errors': repr(self.field_errors),
         }
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         base_dict = super().to_dict()
         return {
             **base_dict,

--- a/src/validataclass/exceptions/email_exceptions.py
+++ b/src/validataclass/exceptions/email_exceptions.py
@@ -4,7 +4,7 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'InvalidEmailError',

--- a/src/validataclass/exceptions/list_exceptions.py
+++ b/src/validataclass/exceptions/list_exceptions.py
@@ -4,9 +4,9 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'ListItemsValidationError',
@@ -27,7 +27,7 @@ class ListItemsValidationError(ValidationError):
     code = 'list_item_errors'
     item_errors: Dict[int, ValidationError]
 
-    def __init__(self, *, item_errors: Dict[int, ValidationError], **kwargs):
+    def __init__(self, *, item_errors: Dict[int, ValidationError], **kwargs: Any):
         super().__init__(**kwargs)
         assert all(isinstance(error, ValidationError) for error in item_errors.values())
         self.item_errors = item_errors
@@ -39,7 +39,7 @@ class ListItemsValidationError(ValidationError):
             'item_errors': repr(self.item_errors),
         }
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         base_dict = super().to_dict()
         return {
             **base_dict,
@@ -58,7 +58,9 @@ class ListLengthError(ValidationError):
     """
     code = 'list_invalid_length'
 
-    def __init__(self, *, min_length: Optional[int] = None, max_length: Optional[int] = None, **kwargs):
-        min_length_args = {'min_length': min_length} if min_length is not None else {}
-        max_length_args = {'max_length': max_length} if max_length is not None else {}
-        super().__init__(**min_length_args, **max_length_args, **kwargs)
+    def __init__(self, *, min_length: Optional[int] = None, max_length: Optional[int] = None, **kwargs: Any):
+        if min_length is not None:
+            kwargs.update(min_length=min_length)
+        if max_length is not None:
+            kwargs.update(max_length=max_length)
+        super().__init__(**kwargs)

--- a/src/validataclass/exceptions/misc_exceptions.py
+++ b/src/validataclass/exceptions/misc_exceptions.py
@@ -4,9 +4,9 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Optional
+from typing import Any, List, Optional
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'ValueNotAllowedError',
@@ -22,5 +22,5 @@ class ValueNotAllowedError(ValidationError):
     """
     code = 'value_not_allowed'
 
-    def __init__(self, *, allowed_values: Optional[list] = None, **kwargs):
+    def __init__(self, *, allowed_values: Optional[List[Any]] = None, **kwargs: Any):
         super().__init__(allowed_values=allowed_values, **kwargs)

--- a/src/validataclass/exceptions/number_exceptions.py
+++ b/src/validataclass/exceptions/number_exceptions.py
@@ -6,7 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any, Optional
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'NumberRangeError',
@@ -27,10 +27,12 @@ class NumberRangeError(ValidationError):
     """
     code = 'number_range_error'
 
-    def __init__(self, *, min_value: Optional[Any] = None, max_value: Optional[Any] = None, **kwargs):
-        min_value_args = {'min_value': min_value} if min_value is not None else {}
-        max_value_args = {'max_value': max_value} if max_value is not None else {}
-        super().__init__(**min_value_args, **max_value_args, **kwargs)
+    def __init__(self, *, min_value: Optional[Any] = None, max_value: Optional[Any] = None, **kwargs: Any):
+        if min_value is not None:
+            kwargs.update(min_value=min_value)
+        if max_value is not None:
+            kwargs.update(max_value=max_value)
+        super().__init__(**kwargs)
 
 
 class DecimalPlacesError(ValidationError):
@@ -42,10 +44,12 @@ class DecimalPlacesError(ValidationError):
     """
     code = 'decimal_places'
 
-    def __init__(self, *, min_places: Optional[Any] = None, max_places: Optional[Any] = None, **kwargs):
-        min_places_args = {'min_places': min_places} if min_places is not None else {}
-        max_places_args = {'max_places': max_places} if max_places is not None else {}
-        super().__init__(**min_places_args, **max_places_args, **kwargs)
+    def __init__(self, *, min_places: Optional[Any] = None, max_places: Optional[Any] = None, **kwargs: Any):
+        if min_places is not None:
+            kwargs.update(min_places=min_places)
+        if max_places is not None:
+            kwargs.update(max_places=max_places)
+        super().__init__(**kwargs)
 
 
 class InvalidIntegerError(ValidationError):

--- a/src/validataclass/exceptions/regex_exceptions.py
+++ b/src/validataclass/exceptions/regex_exceptions.py
@@ -4,7 +4,7 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'RegexMatchError',

--- a/src/validataclass/exceptions/string_exceptions.py
+++ b/src/validataclass/exceptions/string_exceptions.py
@@ -4,9 +4,9 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Optional
+from typing import Any, Optional
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'StringInvalidLengthError',
@@ -26,10 +26,12 @@ class StringInvalidLengthError(ValidationError):
     # Placeholder, will be overridden by the subclasses
     code = 'string_invalid_length'
 
-    def __init__(self, *, min_length: Optional[int] = None, max_length: Optional[int] = None, **kwargs):
-        min_length_args = {'min_length': min_length} if min_length is not None else {}
-        max_length_args = {'max_length': max_length} if max_length is not None else {}
-        super().__init__(**min_length_args, **max_length_args, **kwargs)
+    def __init__(self, *, min_length: Optional[int] = None, max_length: Optional[int] = None, **kwargs: Any):
+        if min_length is not None:
+            kwargs.update(min_length=min_length)
+        if max_length is not None:
+            kwargs.update(max_length=max_length)
+        super().__init__(**kwargs)
 
 
 class StringTooShortError(StringInvalidLengthError):
@@ -41,7 +43,7 @@ class StringTooShortError(StringInvalidLengthError):
     """
     code = 'string_too_short'
 
-    def __init__(self, *, min_length: int, max_length: Optional[int] = None, **kwargs):
+    def __init__(self, *, min_length: int, max_length: Optional[int] = None, **kwargs: Any):
         super().__init__(min_length=min_length, max_length=max_length, **kwargs)
 
 
@@ -54,7 +56,7 @@ class StringTooLongError(StringInvalidLengthError):
     """
     code = 'string_too_long'
 
-    def __init__(self, *, min_length: Optional[int] = None, max_length: int, **kwargs):
+    def __init__(self, *, min_length: Optional[int] = None, max_length: int, **kwargs: Any):
         super().__init__(min_length=min_length, max_length=max_length, **kwargs)
 
 

--- a/src/validataclass/exceptions/url_exceptions.py
+++ b/src/validataclass/exceptions/url_exceptions.py
@@ -4,7 +4,7 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from validataclass.exceptions import ValidationError
+from .base_exceptions import ValidationError
 
 __all__ = [
     'InvalidUrlError',

--- a/src/validataclass/helpers/__init__.py
+++ b/src/validataclass/helpers/__init__.py
@@ -6,6 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 import importlib
 import warnings
+from typing import Any
 
 from .datetime_range import BaseDateTimeRange, DateTimeRange, DateTimeOffsetRange
 from .unset_value import UnsetValue, UnsetValueType, OptionalUnset, OptionalUnsetNone, unset_to_none
@@ -19,7 +20,7 @@ __all__ = [
 
 # DEPRECATED: Allow importing of moved modules for compatibility reasons. This is going to be removed in a future
 # version (presumably 1.0.0).
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     if name in [
         'Default', 'DefaultFactory', 'DefaultUnset', 'NoDefault',
         'validataclass', 'validataclass_field', 'ValidataclassMixin',

--- a/src/validataclass/helpers/datetime_range.py
+++ b/src/validataclass/helpers/datetime_range.py
@@ -47,7 +47,7 @@ class BaseDateTimeRange(ABC):
         Helper method to resolve callables to datetime objects and to apply `local_timezone` if necessary.
         """
         # Resolve callable to an actual datetime
-        boundary_datetime = boundary() if isinstance(boundary, Callable) else boundary
+        boundary_datetime = boundary() if callable(boundary) else boundary
 
         # For local datetimes, set timezone if local_timezone is given
         if boundary_datetime is not None and boundary_datetime.tzinfo is None and local_timezone is not None:
@@ -92,7 +92,7 @@ class DateTimeRange(BaseDateTimeRange):
         self.lower_boundary = lower_boundary
         self.upper_boundary = upper_boundary
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{type(self).__name__}(lower_boundary={self.lower_boundary!r}, upper_boundary={self.upper_boundary!r})'
 
     def contains_datetime(self, dt: datetime, local_timezone: Optional[tzinfo] = None) -> bool:
@@ -189,7 +189,7 @@ class DateTimeOffsetRange(BaseDateTimeRange):
         self.offset_minus = offset_minus
         self.offset_plus = offset_plus
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'{type(self).__name__}(pivot={self.pivot!r}, offset_minus={self.offset_minus!r}, '
             f'offset_plus={self.offset_plus!r})'

--- a/src/validataclass/helpers/datetime_range.py
+++ b/src/validataclass/helpers/datetime_range.py
@@ -24,14 +24,14 @@ class BaseDateTimeRange(ABC):
     Abstract base class to implement datetime ranges (to be used with `DateTimeValidator`).
     """
 
-    @abstractmethod  # pragma: nocover
+    @abstractmethod
     def contains_datetime(self, dt: datetime, local_timezone: Optional[tzinfo] = None) -> bool:
         """
         Abstract method to be implemented by subclasses. Should return `True` if a datetime is contained in the range.
         """
         raise NotImplementedError()
 
-    @abstractmethod  # pragma: nocover
+    @abstractmethod
     def to_dict(self, local_timezone: Optional[tzinfo] = None) -> Dict[str, str]:
         """
         Abstract method to be implemented by subclasses. Should return a dictionary with string representations of the

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -64,4 +64,4 @@ def unset_to_none(value: OptionalUnset[T]) -> Optional[T]:
 
     Returns `None` if the given value is `UnsetValue`, otherwise the value is returned unmodified.
     """
-    return None if value is UnsetValue else value
+    return None if isinstance(value, UnsetValueType) else value

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Optional, TypeVar, Union
 
+from typing_extensions import Self
+
 __all__ = [
     'UnsetValue',
     'UnsetValueType',
@@ -28,16 +30,16 @@ class UnsetValueType:
     or to create a copy of `UnsetValue` will always result in the same instance.
     """
 
-    def __call__(self):
+    def __call__(self) -> Self:
         return self
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'UnsetValue'
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '<UnsetValue>'
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return False
 
     # Don't define __eq__ because the default implementation is fine (identity check), and because we would then have to

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -48,7 +48,7 @@ class UnsetValueType:
 
 # Create sentinel object and redefine __new__ so that the object cannot be cloned
 UnsetValue = UnsetValueType()
-UnsetValueType.__new__ = lambda cls: UnsetValue
+UnsetValueType.__new__ = lambda cls: UnsetValue  # type: ignore
 
 # Type alias OptionalUnset[T] for fields with DefaultUnset: Allows either the type T or UnsetValue
 OptionalUnset = Union[T, UnsetValueType]

--- a/src/validataclass/internal/internet_helpers.py
+++ b/src/validataclass/internal/internet_helpers.py
@@ -7,6 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 import ipaddress
 import re
 
+from typing import Pattern
+
 __all__ = [
     'validate_hostname',
     'validate_ip_address',
@@ -17,15 +19,15 @@ __all__ = [
 _REGEX_DOMAIN_LABEL = r'([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)'
 
 # Precompiled regular expressions
-_ip_charset_regex: re.Pattern = re.compile(
+_ip_charset_regex: Pattern[str] = re.compile(
     r'(\d+\.){3}\d+|\[[0-9a-f:]+]',
     re.ASCII | re.IGNORECASE,
 )
-_domain_optional_tld_regex: re.Pattern = re.compile(
+_domain_optional_tld_regex: Pattern[str] = re.compile(
     f'({_REGEX_DOMAIN_LABEL}\\.)*{_REGEX_DOMAIN_LABEL}',
     re.IGNORECASE,
 )
-_domain_required_tld_regex: re.Pattern = re.compile(
+_domain_required_tld_regex: Pattern[str] = re.compile(
     f'({_REGEX_DOMAIN_LABEL}\\.)+{_REGEX_DOMAIN_LABEL}',
     re.IGNORECASE,
 )

--- a/src/validataclass/validators/allow_empty_string.py
+++ b/src/validataclass/validators/allow_empty_string.py
@@ -62,7 +62,7 @@ class AllowEmptyString(Validator):
         self.wrapped_validator = validator
         self.default_value = default
 
-    def validate(self, input_data: Any, **kwargs) -> Optional[Any]:
+    def validate(self, input_data: Any, **kwargs: Any) -> Optional[Any]:
         """
         Validates input data.
 

--- a/src/validataclass/validators/any_of_validator.py
+++ b/src/validataclass/validators/any_of_validator.py
@@ -58,10 +58,10 @@ class AnyOfValidator(Validator):
     max_allowed_values_in_validation_error: int = 20
 
     # Values allowed as input
-    allowed_values: List[Any] = None
+    allowed_values: List[Any]
 
     # Types allowed for input data (set by parameter or autodetermined from allowed_values)
-    allowed_types: List[type] = None
+    allowed_types: List[type]
 
     # If set, strings will be matched case-sensitively
     case_sensitive: bool = False
@@ -119,7 +119,7 @@ class AnyOfValidator(Validator):
         # Set case_sensitive parameter, defaulting to False.
         self.case_sensitive = case_sensitive if case_sensitive is not None else False
 
-    def validate(self, input_data: Any, **kwargs) -> Any:
+    def validate(self, input_data: Any, **kwargs: Any) -> Any:
         """
         Validate that input is in the list of allowed values. Returns the value (as defined in the list).
         """
@@ -152,6 +152,6 @@ class AnyOfValidator(Validator):
 
         # Compare strings case-insensitively (unless case_sensitive option is set)
         if type(input_value) is str and not self.case_sensitive:
-            return input_value.lower() == allowed_value.lower()
+            return bool(input_value.lower() == allowed_value.lower())
         else:
-            return input_value == allowed_value
+            return bool(input_value == allowed_value)

--- a/src/validataclass/validators/anything_validator.py
+++ b/src/validataclass/validators/anything_validator.py
@@ -70,7 +70,7 @@ class AnythingValidator(Validator):
         self,
         *,
         allow_none: Optional[bool] = None,
-        allowed_types: Optional[Union[Iterable[Union[type, None]], type]] = None,
+        allowed_types: Union[Iterable[Union[type, None]], type, None] = None,
     ):
         """
         Creates an `AnythingValidator` that accepts any input.
@@ -108,7 +108,7 @@ class AnythingValidator(Validator):
     @staticmethod
     def _normalize_allowed_types(
         *,
-        allowed_types: Optional[Union[Iterable[Union[type, None]], type]],
+        allowed_types: Union[Iterable[Union[type, None]], type, None],
         allow_none: Optional[bool],
     ) -> List[type]:
         """
@@ -116,7 +116,7 @@ class AnythingValidator(Validator):
         """
         # If allowed_types is not already an Iterable, put it in a list. (Treating strings as iterable doesn't make
         # sense here, so we make an exception for strings to give the user a more meaningful error message.)
-        if not isinstance(allowed_types, Iterable) or type(allowed_types) is str:
+        if not isinstance(allowed_types, Iterable) or isinstance(allowed_types, str):
             allowed_types = [allowed_types]
 
         # Make sure allowed_types only contains valid types (or None, which is replaced later)
@@ -125,21 +125,21 @@ class AnythingValidator(Validator):
                 raise InvalidValidatorOptionException(f'Element of allowed_types is not a type: {t!r}')
 
         # Convert to a set to remove duplicates and replace None with NoneType while we're on it
-        allowed_types = set(type(None) if t is None else t for t in allowed_types)
+        allowed_types_set = set(type(None) if t is None else t for t in allowed_types)
 
         # If allow_none is set, this parameter overrides whether NoneType is part of the allowed types
         if allow_none is True:
-            allowed_types.add(type(None))
+            allowed_types_set.add(type(None))
         elif allow_none is False:
-            allowed_types.discard(type(None))
+            allowed_types_set.discard(type(None))
 
         # Don't allow empty allowed_types
-        if len(allowed_types) == 0:
+        if len(allowed_types_set) == 0:
             raise InvalidValidatorOptionException('allowed_types is empty. Use the RejectValidator instead.')
 
-        return list(allowed_types)
+        return list(allowed_types_set)
 
-    def validate(self, input_data: Any, **kwargs) -> Any:
+    def validate(self, input_data: Any, **kwargs: Any) -> Any:
         """
         Validates input data. Accepts anything (or only specific types) and returns data unmodified.
         """

--- a/src/validataclass/validators/boolean_validator.py
+++ b/src/validataclass/validators/boolean_validator.py
@@ -47,7 +47,7 @@ class BooleanValidator(Validator):
         """
         self.allow_strings = allow_strings
 
-    def validate(self, input_data: Any, **kwargs) -> bool:
+    def validate(self, input_data: Any, **kwargs: Any) -> bool:
         """
         Validates type of input data. Returns a boolean.
         """

--- a/src/validataclass/validators/dataclass_validator.py
+++ b/src/validataclass/validators/dataclass_validator.py
@@ -244,7 +244,7 @@ class DataclassValidator(Generic[T_Dataclass], DictValidator):
 
         return validated_dict
 
-    def validate(self, input_data: Any, **kwargs: Any) -> T_Dataclass:
+    def validate(self, input_data: Any, **kwargs: Any) -> T_Dataclass:  # type: ignore[override]
         """
         Validate an input dictionary according to the specified dataclass. Returns an instance of the dataclass.
         """

--- a/src/validataclass/validators/date_validator.py
+++ b/src/validataclass/validators/date_validator.py
@@ -42,7 +42,7 @@ class DateValidator(StringValidator):
         # Initialize StringValidator without any parameters
         super().__init__()
 
-    def validate(self, input_data: Any, **kwargs: Any) -> date:
+    def validate(self, input_data: Any, **kwargs: Any) -> date:  # type: ignore[override]
         """
         Validates input as a valid date string and convert it to a `datetime.date` object.
         """

--- a/src/validataclass/validators/date_validator.py
+++ b/src/validataclass/validators/date_validator.py
@@ -33,7 +33,7 @@ class DateValidator(StringValidator):
     Output: `datetime.date`
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Creates a `DateValidator`.
 
@@ -42,7 +42,7 @@ class DateValidator(StringValidator):
         # Initialize StringValidator without any parameters
         super().__init__()
 
-    def validate(self, input_data: Any, **kwargs) -> date:
+    def validate(self, input_data: Any, **kwargs: Any) -> date:
         """
         Validates input as a valid date string and convert it to a `datetime.date` object.
         """

--- a/src/validataclass/validators/datetime_validator.py
+++ b/src/validataclass/validators/datetime_validator.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 import re
 from datetime import datetime, tzinfo
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Pattern
 
 from validataclass.exceptions import DateTimeRangeError, InvalidDateTimeError, InvalidValidatorOptionException
 from validataclass.helpers import BaseDateTimeRange
@@ -282,7 +282,7 @@ class DateTimeValidator(StringValidator):
     datetime_format: DateTimeFormat
 
     # Precompiled regular expression for the specified datetime string format
-    datetime_format_regex: re.Pattern
+    datetime_format_regex: Pattern[str]
 
     # Whether to discard milli- and microseconds in the output datetime
     discard_milliseconds: bool = False

--- a/src/validataclass/validators/datetime_validator.py
+++ b/src/validataclass/validators/datetime_validator.py
@@ -36,7 +36,7 @@ class DateTimeFormat(Enum):
     - `regex_str`: Regular expression pattern as string
     """
 
-    def __init__(self, format_str, regex_str):
+    def __init__(self, format_str: str, regex_str: str):
         self.format_str = format_str
         self.regex_str = regex_str
 
@@ -44,7 +44,11 @@ class DateTimeFormat(Enum):
         """
         Returns `True` if the format allows local datetimes (i.e. datetime strings without timezone info).
         """
-        return True if self in [self.ALLOW_TIMEZONE, self.LOCAL_ONLY, self.LOCAL_OR_UTC] else False
+        return bool(self in [
+            DateTimeFormat.ALLOW_TIMEZONE,
+            DateTimeFormat.LOCAL_ONLY,
+            DateTimeFormat.LOCAL_OR_UTC,
+        ])
 
     # Allows datetimes both with and without timezone info, the latter being interpreted as local time (default)
     ALLOW_TIMEZONE = ('<DATE>T<TIME>[<TIMEZONE>]', f'{_REGEX_DATE_AND_TIME}{_REGEX_TIMEZONE}?')
@@ -339,7 +343,7 @@ class DateTimeValidator(StringValidator):
         # Precompile regular expression for datetime format
         self.datetime_format_regex = re.compile(self.datetime_format.regex_str)
 
-    def validate(self, input_data: Any, **kwargs) -> datetime:
+    def validate(self, input_data: Any, **kwargs: Any) -> datetime:
         """
         Validates input as a valid datetime string and convert it to a `datetime.datetime` object.
         """

--- a/src/validataclass/validators/datetime_validator.py
+++ b/src/validataclass/validators/datetime_validator.py
@@ -343,7 +343,7 @@ class DateTimeValidator(StringValidator):
         # Precompile regular expression for datetime format
         self.datetime_format_regex = re.compile(self.datetime_format.regex_str)
 
-    def validate(self, input_data: Any, **kwargs: Any) -> datetime:
+    def validate(self, input_data: Any, **kwargs: Any) -> datetime:  # type: ignore[override]
         """
         Validates input as a valid datetime string and convert it to a `datetime.datetime` object.
         """

--- a/src/validataclass/validators/decimal_validator.py
+++ b/src/validataclass/validators/decimal_validator.py
@@ -145,7 +145,7 @@ class DecimalValidator(StringValidator):
                 raise InvalidValidatorOptionException('Parameter "output_places" cannot be negative.')
             self.output_quantum = Decimal('0.1') ** output_places
 
-    def validate(self, input_data: Any, **kwargs: Any) -> Decimal:
+    def validate(self, input_data: Any, **kwargs: Any) -> Decimal:  # type: ignore[override]
         """
         Validates input data as a string, convert it to a `Decimal` object and check optional constraints.
         """

--- a/src/validataclass/validators/decimal_validator.py
+++ b/src/validataclass/validators/decimal_validator.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 import decimal
 import re
 from decimal import Decimal, InvalidOperation
-from typing import Any, Optional, Union
+from typing import Any, Optional, Pattern, Union
 
 from validataclass.exceptions import (
     DecimalPlacesError,
@@ -88,7 +88,7 @@ class DecimalValidator(StringValidator):
     rounding: Optional[str] = None
 
     # Precompiled regular expression for decimal values
-    decimal_regex: re.Pattern = re.compile(r'[+-]?([0-9]+\.[0-9]*|\.?[0-9]+)')
+    decimal_regex: Pattern[str] = re.compile(r'[+-]?([0-9]+\.[0-9]*|\.?[0-9]+)')
 
     def __init__(
         self,

--- a/src/validataclass/validators/decimal_validator.py
+++ b/src/validataclass/validators/decimal_validator.py
@@ -145,7 +145,7 @@ class DecimalValidator(StringValidator):
                 raise InvalidValidatorOptionException('Parameter "output_places" cannot be negative.')
             self.output_quantum = Decimal('0.1') ** output_places
 
-    def validate(self, input_data: Any, **kwargs) -> Decimal:
+    def validate(self, input_data: Any, **kwargs: Any) -> Decimal:
         """
         Validates input data as a string, convert it to a `Decimal` object and check optional constraints.
         """

--- a/src/validataclass/validators/dict_validator.py
+++ b/src/validataclass/validators/dict_validator.py
@@ -132,7 +132,7 @@ class DictValidator(Validator):
         if optional_fields is not None:
             self.required_fields = self.required_fields - set(optional_fields)
 
-    def validate(self, input_data: Any, **kwargs) -> dict:
+    def validate(self, input_data: Any, **kwargs: Any) -> Dict[str, Any]:
         """
         Validates input data. Returns a validated dict.
         """
@@ -143,8 +143,8 @@ class DictValidator(Validator):
             if type(key) is not str:
                 raise DictInvalidKeyTypeError()
 
-        field_errors = {}
-        validated_dict = {}
+        field_errors: Dict[str, ValidationError] = {}
+        validated_dict: Dict[str, Any] = {}
 
         # Check that required fields exist in input data
         for field_name in self.required_fields:

--- a/src/validataclass/validators/discard_validator.py
+++ b/src/validataclass/validators/discard_validator.py
@@ -53,7 +53,7 @@ class DiscardValidator(Validator):
         """
         self.output_value = output_value
 
-    def validate(self, input_data: Any, **kwargs) -> Any:
+    def validate(self, input_data: Any, **kwargs: Any) -> Any:
         """
         Validates input data.
         Discards any input and always returns `None` (or the specified `output_value`).

--- a/src/validataclass/validators/email_validator.py
+++ b/src/validataclass/validators/email_validator.py
@@ -88,7 +88,7 @@ class EmailValidator(StringValidator):
         self.allow_empty = allow_empty
         self.to_lowercase = to_lowercase
 
-    def validate(self, input_data: Any, **kwargs) -> str:
+    def validate(self, input_data: Any, **kwargs: Any) -> str:
         """
         Validates that input is a valid email address string. Returns unmodified string.
         """

--- a/src/validataclass/validators/email_validator.py
+++ b/src/validataclass/validators/email_validator.py
@@ -5,7 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 import re
-from typing import Any
+from typing import Any, Pattern
 
 from validataclass.exceptions import InvalidEmailError
 from validataclass.internal import internet_helpers
@@ -51,7 +51,7 @@ class EmailValidator(StringValidator):
     """
 
     # Precompiled regular expression
-    email_regex: re.Pattern = re.compile(
+    email_regex: Pattern[str] = re.compile(
         f'(?P<local_part> {_REGEX_LOCAL_PART_CHARS}+ (?: \\.{_REGEX_LOCAL_PART_CHARS}+)* ) '
         f'@ (?P<domain> [^@?]+ )',
         re.IGNORECASE | re.VERBOSE,

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -4,7 +4,7 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from enum import Enum, EnumMeta
+from enum import Enum
 from typing import Any, Generic, Iterable, Optional, Type, TypeVar, Union
 
 from validataclass.exceptions import InvalidValidatorOptionException, ValueNotAllowedError
@@ -69,13 +69,13 @@ class EnumValidator(Generic[T_Enum], AnyOfValidator):
     """
 
     # Enum class used to determine the list of allowed values
-    enum_cls: Type[Enum]
+    enum_cls: Type[T_Enum]
 
     # TODO: For version 1.0, remove the old parameter "case_insensitive" completely and set a real default value for the
     #  new "case_sensitive" parameter. (See base AnyOfValidator.)
     def __init__(
         self,
-        enum_cls: Type[Enum],
+        enum_cls: Type[T_Enum],
         *,
         allowed_values: Optional[Iterable[Any]] = None,
         allowed_types: Optional[Union[type, Iterable[type]]] = None,
@@ -93,7 +93,7 @@ class EnumValidator(Generic[T_Enum], AnyOfValidator):
             `case_insensitive`: DEPRECATED. Validator is case-insensitive by default (see `case_sensitive`)
         """
         # Ensure parameter is an Enum class
-        if not isinstance(enum_cls, EnumMeta):
+        if not isinstance(enum_cls, type) or not issubclass(enum_cls, Enum):
             raise InvalidValidatorOptionException('Parameter "enum_cls" must be an Enum class.')
 
         self.enum_cls = enum_cls

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -117,7 +117,7 @@ class EnumValidator(Generic[T_Enum], AnyOfValidator):
             case_insensitive=case_insensitive,
         )
 
-    def validate(self, input_data: Any, **kwargs) -> T_Enum:
+    def validate(self, input_data: Any, **kwargs: Any) -> T_Enum:
         """
         Validates input to be a valid value of the specified Enum. Returns the Enum member.
         """

--- a/src/validataclass/validators/float_to_decimal_validator.py
+++ b/src/validataclass/validators/float_to_decimal_validator.py
@@ -113,7 +113,7 @@ class FloatToDecimalValidator(DecimalValidator):
         if allow_strings:
             self.allowed_types.append(str)
 
-    def validate(self, input_data: Any, **kwargs: Any) -> Decimal:
+    def validate(self, input_data: Any, **kwargs: Any) -> Decimal:  # type: ignore[override]
         """
         Validates input data as a float (optionally also as integer or string), then converts it to a `Decimal` object.
         """

--- a/src/validataclass/validators/float_to_decimal_validator.py
+++ b/src/validataclass/validators/float_to_decimal_validator.py
@@ -96,8 +96,8 @@ class FloatToDecimalValidator(DecimalValidator):
         """
         # Initialize base DecimalValidator
         super().__init__(
-            min_value=str(min_value) if type(min_value) in [float, int] else min_value,
-            max_value=str(max_value) if type(max_value) in [float, int] else max_value,
+            min_value=str(min_value) if isinstance(min_value, float) else min_value,
+            max_value=str(max_value) if isinstance(max_value, float) else max_value,
             output_places=output_places,
             rounding=rounding,
         )
@@ -113,7 +113,7 @@ class FloatToDecimalValidator(DecimalValidator):
         if allow_strings:
             self.allowed_types.append(str)
 
-    def validate(self, input_data: Any, **kwargs) -> Decimal:
+    def validate(self, input_data: Any, **kwargs: Any) -> Decimal:
         """
         Validates input data as a float (optionally also as integer or string), then converts it to a `Decimal` object.
         """

--- a/src/validataclass/validators/float_validator.py
+++ b/src/validataclass/validators/float_validator.py
@@ -79,7 +79,7 @@ class FloatValidator(Validator):
         self.max_value = float(max_value) if max_value is not None else None
         self.allow_integers = allow_integers
 
-    def validate(self, input_data: Any, **kwargs) -> float:
+    def validate(self, input_data: Any, **kwargs: Any) -> float:
         """
         Validates type (and optionally value) of input data. Returns unmodified float.
         """

--- a/src/validataclass/validators/integer_validator.py
+++ b/src/validataclass/validators/integer_validator.py
@@ -89,7 +89,7 @@ class IntegerValidator(Validator):
         self.max_value = max_value
         self.allow_strings = allow_strings
 
-    def validate(self, input_data: Any, **kwargs) -> int:
+    def validate(self, input_data: Any, **kwargs: Any) -> int:
         """
         Validates type (and optionally value) of input data. Returns unmodified integer.
         """

--- a/src/validataclass/validators/list_validator.py
+++ b/src/validataclass/validators/list_validator.py
@@ -109,7 +109,7 @@ class ListValidator(Generic[T_ListItem], Validator):
         self.max_length = max_length
         self.discard_invalid = discard_invalid
 
-    def validate(self, input_data: Any, **kwargs) -> List[T_ListItem]:
+    def validate(self, input_data: Any, **kwargs: Any) -> List[T_ListItem]:
         """
         Validates input data. Returns a validated list.
         """

--- a/src/validataclass/validators/noneable.py
+++ b/src/validataclass/validators/noneable.py
@@ -62,7 +62,7 @@ class Noneable(Validator):
         self.wrapped_validator = validator
         self.default_value = default
 
-    def validate(self, input_data: Any, **kwargs) -> Optional[Any]:
+    def validate(self, input_data: Any, **kwargs: Any) -> Optional[Any]:
         """
         Validates input data.
 

--- a/src/validataclass/validators/regex_validator.py
+++ b/src/validataclass/validators/regex_validator.py
@@ -107,7 +107,7 @@ class RegexValidator(StringValidator):
         custom_error_class: Type[ValidationError] = RegexMatchError,
         custom_error_code: Optional[str] = None,
         allow_empty: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ):
         """
         Creates a `RegexValidator` with a specified regex pattern (as string or precompiled `re.Pattern` object).
@@ -144,7 +144,7 @@ class RegexValidator(StringValidator):
 
         self.allow_empty = allow_empty
 
-    def validate(self, input_data: Any, **kwargs) -> str:
+    def validate(self, input_data: Any, **kwargs: Any) -> str:
         """
         Validates input as string and match full string against regular expression.
 

--- a/src/validataclass/validators/regex_validator.py
+++ b/src/validataclass/validators/regex_validator.py
@@ -5,7 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 import re
-from typing import Any, Optional, Type, Union
+from typing import Any, Optional, Pattern, Type, Union
 
 from validataclass.exceptions import RegexMatchError, ValidationError
 from .string_validator import StringValidator
@@ -85,7 +85,7 @@ class RegexValidator(StringValidator):
     """
 
     # Precompiled regex pattern
-    regex_pattern: re.Pattern
+    regex_pattern: Pattern[str]
 
     # Output template
     output_template: Optional[str]
@@ -101,7 +101,7 @@ class RegexValidator(StringValidator):
 
     def __init__(
         self,
-        pattern: Union[re.Pattern, str],
+        pattern: Union[Pattern[str], str],
         output_template: Optional[str] = None,
         *,
         custom_error_class: Type[ValidationError] = RegexMatchError,

--- a/src/validataclass/validators/reject_validator.py
+++ b/src/validataclass/validators/reject_validator.py
@@ -93,7 +93,7 @@ class RejectValidator(Validator):
         self.error_code = error_code
         self.error_reason = error_reason
 
-    def validate(self, input_data: Any, **kwargs) -> None:
+    def validate(self, input_data: Any, **kwargs: Any) -> None:
         """
         Validates input data. In this case, reject any value (except for `None` if `allow_none` is set).
         """

--- a/src/validataclass/validators/string_validator.py
+++ b/src/validataclass/validators/string_validator.py
@@ -110,7 +110,7 @@ class StringValidator(Validator):
         self.allow_multiline = multiline
         self.unsafe = unsafe
 
-    def validate(self, input_data: Any, **kwargs) -> str:
+    def validate(self, input_data: Any, **kwargs: Any) -> str:
         """
         Validates input data to be a valid string, optionally checking length and allowed characters.
 

--- a/src/validataclass/validators/time_validator.py
+++ b/src/validataclass/validators/time_validator.py
@@ -94,7 +94,7 @@ class TimeValidator(StringValidator):
         self.time_format = time_format
         self.time_format_regex = re.compile(self.time_format.regex_str)
 
-    def validate(self, input_data: Any, **kwargs: Any) -> time:
+    def validate(self, input_data: Any, **kwargs: Any) -> time:  # type: ignore[override]
         """
         Validates input as a valid time string and convert it to a `datetime.time` object.
         """

--- a/src/validataclass/validators/time_validator.py
+++ b/src/validataclass/validators/time_validator.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 import re
 from datetime import time
 from enum import Enum
-from typing import Any
+from typing import Any, Pattern
 
 from validataclass.exceptions import InvalidTimeError
 from .string_validator import StringValidator
@@ -78,7 +78,7 @@ class TimeValidator(StringValidator):
     time_format: TimeFormat
 
     # Precompiled regular expression for the specified time string format
-    time_format_regex: re.Pattern
+    time_format_regex: Pattern[str]
 
     def __init__(self, time_format: TimeFormat = TimeFormat.WITH_SECONDS):
         """

--- a/src/validataclass/validators/time_validator.py
+++ b/src/validataclass/validators/time_validator.py
@@ -28,7 +28,7 @@ class TimeFormat(Enum):
     - `regex_str`: Regular expression pattern as string
     """
 
-    def __init__(self, format_str, regex_str):
+    def __init__(self, format_str: str, regex_str: str):
         self.format_str = format_str
         self.regex_str = regex_str
 
@@ -94,7 +94,7 @@ class TimeValidator(StringValidator):
         self.time_format = time_format
         self.time_format_regex = re.compile(self.time_format.regex_str)
 
-    def validate(self, input_data: Any, **kwargs) -> time:
+    def validate(self, input_data: Any, **kwargs: Any) -> time:
         """
         Validates input as a valid time string and convert it to a `datetime.time` object.
         """

--- a/src/validataclass/validators/url_validator.py
+++ b/src/validataclass/validators/url_validator.py
@@ -5,7 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 import re
-from typing import Any, Optional, List
+from typing import Any, List, Optional, Pattern
 
 from validataclass.exceptions import InvalidUrlError
 from validataclass.internal import internet_helpers
@@ -84,7 +84,7 @@ class UrlValidator(StringValidator):
     allow_empty: bool
 
     # Precompiled regular expression
-    url_regex: re.Pattern = re.compile(
+    url_regex: Pattern[str] = re.compile(
         r'''
             (?P<scheme> [a-z][a-z0-9.+-]* )
             ://

--- a/src/validataclass/validators/url_validator.py
+++ b/src/validataclass/validators/url_validator.py
@@ -138,7 +138,7 @@ class UrlValidator(StringValidator):
         self.allow_userinfo = allow_userinfo
         self.allow_empty = allow_empty
 
-    def validate(self, input_data: Any, **kwargs) -> str:
+    def validate(self, input_data: Any, **kwargs: Any) -> str:
         """
         Validates that input is a valid URL string. Returns unmodified string.
         """

--- a/src/validataclass/validators/validator.py
+++ b/src/validataclass/validators/validator.py
@@ -21,7 +21,7 @@ class Validator(ABC):
     Base class for building extendable validator classes that validate, sanitize and transform input.
     """
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs: Any):
         # Check if subclasses are future-proof
         if inspect.getfullargspec(cls.validate).varkw is None:
             warnings.warn(
@@ -33,7 +33,7 @@ class Validator(ABC):
         super().__init_subclass__(**kwargs)
 
     @abstractmethod  # pragma: nocover
-    def validate(self, input_data: Any, **kwargs):
+    def validate(self, input_data: Any, **kwargs: Any) -> Any:
         """
         Validates input data. Returns sanitized data or raises a `ValidationError` (or any subclass).
 
@@ -46,7 +46,7 @@ class Validator(ABC):
         """
         raise NotImplementedError()
 
-    def validate_with_context(self, input_data: Any, **kwargs):
+    def validate_with_context(self, input_data: Any, **kwargs: Any) -> Any:
         """
         This method is a wrapper for `validate()` that always accepts arbitrary keyword arguments (which can be used
         for context-sensitive validation).
@@ -85,9 +85,9 @@ class Validator(ABC):
         self._ensure_not_none(input_data)
 
         # Normalize expected_types to a list
-        if type(expected_types) is not list:
+        if not isinstance(expected_types, list):
             expected_types = [expected_types]
 
         # Ensure input has correct type
         if type(input_data) not in expected_types:
-            raise InvalidTypeError(expected_types=expected_types)
+            raise InvalidTypeError(expected_types=list(expected_types))

--- a/src/validataclass/validators/validator.py
+++ b/src/validataclass/validators/validator.py
@@ -32,7 +32,7 @@ class Validator(ABC):
 
         super().__init_subclass__(**kwargs)
 
-    @abstractmethod  # pragma: nocover
+    @abstractmethod
     def validate(self, input_data: Any, **kwargs: Any) -> Any:
         """
         Validates input data. Returns sanitized data or raises a `ValidationError` (or any subclass).

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,6 +109,6 @@ class UnitTestContextValidator(Validator):
     def __init__(self, *, prefix: str = ''):
         self.prefix = f'[{prefix}] ' if prefix else ''
 
-    def validate(self, input_data: Any, **kwargs) -> str:
+    def validate(self, input_data: Any, **kwargs: Any) -> str:
         self._ensure_type(input_data, str)
         return f'{self.prefix}{input_data} / {kwargs}'

--- a/tests/validators/dataclass_validator_test.py
+++ b/tests/validators/dataclass_validator_test.py
@@ -1067,28 +1067,22 @@ class DataclassValidatorTest:
         )
 
     @staticmethod
-    def test_invalid_dataclass_validator_with_invalid_dataclass():
+    @pytest.mark.parametrize(
+        'dataclass_cls_param',
+        [
+            # Type that is not a dataclass (anonymous class)
+            type('UnitTestClass', (), {}),
+
+            # Instance of a dataclass (but not the class itself)
+            UnitTestDataclass(name='bluenana', color='blue', amount=3, weight=Decimal('1.234')),
+        ],
+    )
+    def test_invalid_dataclass_validator_with_invalid_dataclass(dataclass_cls_param):
         """ Test that a DataclassValidator cannot be created with a class that is not a dataclass. """
-
-        class Foo:
-            bar: int = IntegerValidator()
-
         with pytest.raises(InvalidValidatorOptionException) as exception_info:
-            DataclassValidator(Foo)
+            DataclassValidator(dataclass_cls_param)  # noqa
 
         assert str(exception_info.value) == 'Parameter "dataclass_cls" must be a dataclass type.'
-
-    @staticmethod
-    def test_invalid_dataclass_validator_with_dataclass_instance():
-        """ Test that a DataclassValidator cannot be created with an *instance* of a dataclass. """
-        with pytest.raises(InvalidValidatorOptionException) as exception_info:
-            dataclass_instance = UnitTestDataclass(name='bluenana', color='blue', amount=3, weight=Decimal('1.234'))
-            DataclassValidator(dataclass_instance)  # noqa
-
-        assert (
-            str(exception_info.value)
-            == 'Parameter "dataclass_cls" is a dataclass instance, but must be a dataclass type.'
-        )
 
     # Test DataclassValidator with incompatible dataclasses
 

--- a/tests/validators/enum_validator_test.py
+++ b/tests/validators/enum_validator_test.py
@@ -438,10 +438,20 @@ class EnumValidatorTest:
     # Invalid validator parameters
 
     @staticmethod
-    def test_enum_cls_invalid():
+    @pytest.mark.parametrize(
+        'enum_cls_param',
+        [
+            # Member of an Enum class
+            UnitTestStringEnum.STRAWBERRY,
+
+            # Type that is not an Enum class (anonymous class)
+            type('UnitTestClass', (), {}),
+        ],
+    )
+    def test_enum_cls_invalid(enum_cls_param):
         """ Check that EnumValidator raises exception when enum_cls is not an Enum. """
         with pytest.raises(InvalidValidatorOptionException) as exception_info:
-            EnumValidator('banana')  # noqa
+            EnumValidator(enum_cls_param)  # noqa
 
         assert str(exception_info.value) == 'Parameter "enum_cls" must be an Enum class.'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 minversion = 4.5.1
-# TODO: Add mypy to the default environments when all issues are fixed.
-envlist = clean,py{312,311,310,39,38},flake8,report
+envlist = clean,py{312,311,310,39,38},report,flake8,mypy
 skip_missing_interpreters = true
 isolated_build = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 minversion = 4.5.1
+# TODO: Add mypy to the default environments when all issues are fixed.
 envlist = clean,py{312,311,310,39,38},flake8,report
 skip_missing_interpreters = true
 isolated_build = true
@@ -22,6 +23,11 @@ commands = python -m pytest --cov --cov-append {posargs}
 skip_install = true
 deps = flake8
 commands = flake8 src/ tests/
+
+[testenv:mypy,py{312,311,310,39,38}-mypy]
+skip_install = true
+deps = mypy
+commands = mypy
 
 [testenv:clean]
 skip_install = true


### PR DESCRIPTION
This PR integrates mypy as a static type checker into the development environment and the CI pipeline. To do that, it fixes a bunch of typing issues in the library code. It solves a part of #116 (but not all of it as that would be too big of a scope).

List of general changes:

- Add mypy to dev environment (tox, Makefile)
- Add mypy to CI pipeline (GitHub Actions)
- Set mypy rules to strict (apart from `no_implicit_reexport`)

List of code changes:

- Add a lot of missing type hints and fix some incorrect/inaccurate ones
- Replace some type checks with more type-safe ones (e.g. `isinstance` instead of `type(...) is`)
- Exception classes: use relative imports to import base ValidationError
- Improve dynamic keyword argument construction in some classes like [here](https://github.com/binary-butterfly/validataclass/pull/120/commits/027ab1a9f273d43844308ae4f37f57dae8e6ffa1#diff-35059a70cee3bcbed31c465028dd5d37727743ac93a0e066e29cc72c58070ffcR61-R66)
- `FloatToDecimalValidator`: `min_value`/`max_value` will not be cast to string if specified as integer anymore (see [commit](https://github.com/binary-butterfly/validataclass/pull/120/commits/027ab1a9f273d43844308ae4f37f57dae8e6ffa1#diff-35942654b8e76bfaba18cfca910da74f8cb750a03ad76f5f778dc77bdf436be1R99-R100))
- `EnumValidator`: Improve type checking of Enum class when creating the validator (https://github.com/binary-butterfly/validataclass/pull/120/commits/9cbf9f9d1eab9f66d2fefd1b4d0a96e7b926e9c2)
- `DataclassValidator`: (https://github.com/binary-butterfly/validataclass/pull/120/commits/0b6ed6ebe0b37bc2c7125729684da57d5da10bf9)
  - Improve check if given dataclass is actually a dataclass
  - Simplified dataclass check and error handling: There is now only one error message for "parameter is a class that is not a dataclass" and "parameter is an instance of a dataclass".
  - Properly type `dataclasses.Field` with type parameter (requires extra code because in Python 3.8 it is not a Generic yet)
- Use parametrized `Pattern` type hints for regex patterns (uses `typing.Pattern` for now, because `re.Pattern` is not yet parametrized in Python 3.8) (https://github.com/binary-butterfly/validataclass/pull/120/commits/a0d0f546d58a9d22ccb7adcde6f3d5fea8e70893)
- `ValidataclassMixin`: Add a `# type: ignore[call-overload]` for the warning about `asdict` (https://github.com/binary-butterfly/validataclass/pull/120/commits/28110ce9da57958d694d210f31a73e0c5f549cca)
- Add `# type: ignore[override]` for `validate()` overrides in validator classes that return different types than their base validators (e.g. `DecimalValidator` returning `Decimal`, which is not compatible with `StringValidator` returning `str`) (https://github.com/binary-butterfly/validataclass/pull/120/commits/712ac98d798bb159e2ce7c4ec2d3fdbb08dd1fff)
- Add `# type: ignore` for sentinel object creation (https://github.com/binary-butterfly/validataclass/pull/120/commits/3965efe2d8ccb8df372ea05c25dae4afdff9c086)
  - There might be a better way to do this, but sentinels are weird, there should be language support for it.
- `unset_to_none()`: Use `isinstance(value, UnsetValueType)` instead of `is UnsetValue` (again, sentinels are weird) (https://github.com/binary-butterfly/validataclass/pull/120/commits/5ceea7434e1d50abfbd52102e9195529690becbd)
- Fix typing in `DateTimeRange` and `DateTimeOffsetRange` (https://github.com/binary-butterfly/validataclass/pull/120/commits/f7dd402be20a49d19f987a8a8fd387a163bc8f85)
- Various small changes to fix mypy issues