### PR TITLE
Add unit tests to mypy targets; fix typing in tests (part of #116)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ write_to = "src/validataclass/_version.py"
 version_scheme = "post-release"
 
 [tool.mypy]
-# TODO: Don't add tests permanently yet, there's too much that can't be fixed right now.
-# files = ["src/", "tests/"]
-files = "src/"
+files = ["src/", "tests/"]
 mypy_path = "src/"
 explicit_package_bases = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,25 @@ write_to = "src/validataclass/_version.py"
 version_scheme = "post-release"
 
 [tool.mypy]
+# TODO: Don't add tests permanently yet, there's too much that can't be fixed right now.
+# files = ["src/", "tests/"]
 files = "src/"
+mypy_path = "src/"
+explicit_package_bases = true
 
 # Enable strict type checking
 strict = true
 
 # Ignore errors like `Module "validataclass.exceptions" does not explicitly export attribute "..."`
 no_implicit_reexport = false
+
+[[tool.mypy.overrides]]
+module = 'tests.*'
+
+# Don't enforce typed definitions in tests, this is a lot of unnecessary work (most parameters would be Any anyway).
+allow_untyped_defs = true
+
+# TODO: This is the main issue with mypy and validataclass right now.
+# Defining dataclasses with validators using the @validataclass decorator, like `some_field: str = StringValidator()`,
+# will cause "Incompatible types in assignment" errors. Until we find a way to solve this, ignore this error for now.
+disable_error_code = "assignment"

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,4 @@ testing =
     coverage-conditional-plugin ~= 0.5
     flake8 ~= 7.0
     mypy ~= 1.9
+    types-python-dateutil

--- a/tests/dataclasses/_helpers.py
+++ b/tests/dataclasses/_helpers.py
@@ -54,6 +54,7 @@ def assert_field_no_default(field: T_DataclassField) -> None:
 
     # For Python under 3.10, check that an exception raising default_factory is set
     if sys.version_info < (3, 10):
+        assert field.default_factory is not dataclasses.MISSING
         with pytest.raises(TypeError, match="required keyword-only argument"):
             field.default_factory()
     else:

--- a/tests/dataclasses/defaults_test.py
+++ b/tests/dataclasses/defaults_test.py
@@ -5,6 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from copy import copy
+from typing import Any, List
 
 import pytest
 
@@ -42,7 +43,7 @@ class DefaultTest:
     @staticmethod
     def test_default_list_deepcopied():
         """ Test Default object with a list, make sure that it is deepcopied. """
-        default_list = []
+        default_list: List[Any] = []
         default = Default(default_list)
 
         # Check string representation and value

--- a/tests/dataclasses/validataclass_test.py
+++ b/tests/dataclasses/validataclass_test.py
@@ -5,7 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 import dataclasses
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import pytest
 
@@ -19,7 +19,7 @@ from validataclass.dataclasses import (
     validataclass_field,
 )
 from validataclass.exceptions import DataclassValidatorFieldException
-from validataclass.helpers import OptionalUnset, UnsetValue
+from validataclass.helpers import OptionalUnset, UnsetValue, UnsetValueType
 from validataclass.validators import (
     DictValidator,
     IntegerValidator,
@@ -279,7 +279,7 @@ class ValidatorDataclassTest:
         # Check type annotations
         assert all(fields[field].type is int for field in ['required1', 'required2', 'optional2', 'optional4'])
         assert all(fields[field].type is Optional[int] for field in ['required3', 'optional1'])
-        assert all(fields[field].type is OptionalUnset[int] for field in ['required4', 'optional3'])
+        assert all(fields[field].type is Union[int, UnsetValueType] for field in ['required4', 'optional3'])
 
         # Check validators
         assert all(type(field.metadata.get('validator')) is IntegerValidator for field in fields.values())
@@ -391,7 +391,7 @@ class ValidatorDataclassTest:
             field_both: str = StringValidator()
 
         @validataclass
-        class SubClass(BaseB, BaseA):
+        class SubClass(BaseB, BaseA):  # type: ignore[misc]
             # Override the defaults to test that the decorator recognizes all fields of both base classes.
             # If it does not, a "no validator for field X" error would be raised.
             field_a: int = Default(42)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,12 +5,12 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
-from typing import Any, List, Union
+from typing import Any, List, Tuple, Union
 
 from validataclass.validators import Validator
 
 
-def unpack_params(*args) -> List[tuple]:
+def unpack_params(*args: Any) -> List[Tuple[Any, ...]]:
     """
     Returns a list containing tuples build from the arguments.
 
@@ -64,7 +64,7 @@ def unpack_params(*args) -> List[tuple]:
     ]
     ```
     """
-    unpacked = [tuple()]
+    unpacked: List[Tuple[Any, ...]] = [tuple()]
 
     for arg in args:
         if type(arg) is list:

--- a/tests/validators/datetime_validator_test.py
+++ b/tests/validators/datetime_validator_test.py
@@ -506,10 +506,14 @@ class DateTimeValidatorTest:
         assert validated_dt == expected_datetime
 
         # Check timezone of datetimes by comparing their offset to UTC
-        assert (
-            validated_dt.tzinfo == expected_datetime.tzinfo
-            or validated_dt.tzinfo.utcoffset(validated_dt) == expected_datetime.tzinfo.utcoffset(expected_datetime)
-        )
+        if expected_datetime.tzinfo is None:
+            assert validated_dt.tzinfo is None
+        else:
+            assert validated_dt.tzinfo is not None
+            assert (
+                validated_dt.tzinfo == expected_datetime.tzinfo
+                or validated_dt.tzinfo.utcoffset(validated_dt) == expected_datetime.tzinfo.utcoffset(expected_datetime)
+            )
 
     # Test DateTimeValidator with target_timezone parameter
 

--- a/tests/validators/dict_validator_test.py
+++ b/tests/validators/dict_validator_test.py
@@ -563,7 +563,7 @@ class DictValidatorTest:
                 'value': DecimalValidator(),
                 'optional_value': DecimalValidator(),
             }
-            required_fields = ['name', 'value']
+            required_fields = {'name', 'value'}
 
         validator = UnitTestDictValidator()
         assert validator.validate(input_dict) == expected_output
@@ -608,7 +608,7 @@ class DictValidatorTest:
                 'value': DecimalValidator(),
                 'optional_value': DecimalValidator(),
             }
-            required_fields = ['name', 'value']
+            required_fields = {'name', 'value'}
 
         validator = UnitTestDictValidator()
 

--- a/tests/validators/discard_validator_test.py
+++ b/tests/validators/discard_validator_test.py
@@ -4,6 +4,8 @@ Copyright (c) 2022, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
+from typing import Any, List
+
 import pytest
 
 from validataclass.helpers import UnsetValue
@@ -15,7 +17,7 @@ class DiscardValidatorTest:
     Unit tests for the DiscardValidator.
     """
 
-    example_input_data = [
+    example_input_data: List[Any] = [
         None,
         True,
         False,

--- a/tests/validators/float_validator_test.py
+++ b/tests/validators/float_validator_test.py
@@ -4,6 +4,8 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
+from typing import Any, Dict
+
 import pytest
 
 from validataclass.exceptions import (
@@ -131,7 +133,7 @@ class FloatValidatorTest:
         validator = FloatValidator(min_value=min_value, max_value=max_value)
 
         # Construct error dict with min_value and/or max_value, depending on which is specified
-        expected_error_dict = {'code': 'number_range_error'}
+        expected_error_dict: Dict[str, Any] = {'code': 'number_range_error'}
         expected_error_dict.update({'min_value': float(min_value)} if min_value is not None else {})
         expected_error_dict.update({'max_value': float(max_value)} if max_value is not None else {})
 

--- a/tests/validators/list_validator_test.py
+++ b/tests/validators/list_validator_test.py
@@ -29,21 +29,21 @@ class ListValidatorTest:
     @staticmethod
     def test_valid_integer_list():
         """ Test ListValidator with IntegerValidator as item validator with valid integers. """
-        validator = ListValidator(item_validator=IntegerValidator())
+        validator: ListValidator[int] = ListValidator(item_validator=IntegerValidator())
 
         assert validator.validate([123, 0, -42, 123]) == [123, 0, -42, 123]
 
     @staticmethod
     def test_valid_integer_list_empty():
         """ Test ListValidator with IntegerValidator as item validator with an empty list. """
-        validator = ListValidator(item_validator=IntegerValidator())
+        validator: ListValidator[int] = ListValidator(item_validator=IntegerValidator())
 
         assert validator.validate([]) == []
 
     @staticmethod
     def test_valid_decimal_list():
         """ Test ListValidator with DecimalValidator as item validator with valid decimal strings. """
-        validator = ListValidator(item_validator=DecimalValidator())
+        validator: ListValidator[Decimal] = ListValidator(item_validator=DecimalValidator())
         output_list = validator.validate(['3.1415', '-0.42', '0'])
 
         assert all(isinstance(item, Decimal) for item in output_list)
@@ -86,7 +86,7 @@ class ListValidatorTest:
     )
     def test_valid_nested_list(input_list, expected_output):
         """ Test nested ListValidator to validate lists of lists of decimals. """
-        validator = ListValidator(ListValidator(DecimalValidator()))
+        validator: ListValidator[Decimal] = ListValidator(ListValidator(DecimalValidator()))
         output_list = validator.validate(input_list)
 
         for sublist in output_list:
@@ -100,7 +100,7 @@ class ListValidatorTest:
     @staticmethod
     def test_invalid_none():
         """ Check that ListValidator raises exceptions for None as value. """
-        validator = ListValidator(item_validator=IntegerValidator())
+        validator: ListValidator[int] = ListValidator(item_validator=IntegerValidator())
 
         with pytest.raises(RequiredValueError) as exception_info:
             validator.validate(None)
@@ -119,7 +119,7 @@ class ListValidatorTest:
     )
     def test_invalid_not_a_list(input_data):
         """ Check that ListValidator raises exceptions for values that are not of type 'list'. """
-        validator = ListValidator(item_validator=StringValidator())
+        validator: ListValidator[str] = ListValidator(item_validator=StringValidator())
 
         with pytest.raises(InvalidTypeError) as exception_info:
             validator.validate(input_data)
@@ -132,7 +132,7 @@ class ListValidatorTest:
     @staticmethod
     def test_invalid_decimal_list_items():
         """ Test ListValidator with DecimalValidator as item validator with invalid list items. """
-        validator = ListValidator(item_validator=DecimalValidator())
+        validator: ListValidator[Decimal] = ListValidator(item_validator=DecimalValidator())
 
         with pytest.raises(ListItemsValidationError) as exception_info:
             # Indices 1 and 4 are valid; indices 0, 2, 3 raise errors
@@ -158,7 +158,7 @@ class ListValidatorTest:
     @staticmethod
     def test_with_context_arguments():
         """ Test that ListValidator passes context arguments down to the item validator. """
-        validator = ListValidator(item_validator=UnitTestContextValidator())
+        validator: ListValidator[str] = ListValidator(item_validator=UnitTestContextValidator())
 
         assert validator.validate(['unit', 'test']) == [
             "unit / {}",
@@ -201,7 +201,7 @@ class ListValidatorTest:
     )
     def test_list_length_valid(min_length, max_length, input_data):
         """ Test ListValidator with length requirements with lists of the correct length. """
-        validator = ListValidator(
+        validator: ListValidator[int] = ListValidator(
             IntegerValidator(),
             min_length=min_length,
             max_length=max_length,
@@ -239,7 +239,7 @@ class ListValidatorTest:
     )
     def test_list_length_invalid(min_length, max_length, input_data):
         """ Test ListValidator with length requirements with lists of the wrong length. """
-        validator = ListValidator(
+        validator: ListValidator[int] = ListValidator(
             IntegerValidator(),
             min_length=min_length,
             max_length=max_length,
@@ -276,7 +276,7 @@ class ListValidatorTest:
     )
     def test_discarding_invalid_items(input_data, expected_output):
         """ Test that ListValidator with discard_invalid=True discards invalid items. """
-        validator = ListValidator(
+        validator: ListValidator[int] = ListValidator(
             item_validator=IntegerValidator(),
             discard_invalid=True,
         )
@@ -305,7 +305,7 @@ class ListValidatorTest:
         """
         Test that ListValidator with discard_invalid=True handles length requirements correctly, with valid input.
         """
-        validator = ListValidator(
+        validator: ListValidator[int] = ListValidator(
             IntegerValidator(),
             min_length=2,
             max_length=4,
@@ -339,7 +339,7 @@ class ListValidatorTest:
         Before item validation, minimum and maximum length must be checked. After item validation (and potential
         discarding), the minimum length needs to be checked again.
         """
-        validator = ListValidator(
+        validator: ListValidator[int] = ListValidator(
             IntegerValidator(),
             min_length=2,
             max_length=4,

--- a/tests/validators/regex_validator_test.py
+++ b/tests/validators/regex_validator_test.py
@@ -438,7 +438,7 @@ class RegexValidatorTest:
         Test that RegexValidator raises an error on init if the custom error class is not a ValidatonError subclass.
         """
         with pytest.raises(TypeError, match='Custom error class must be a subclass of ValidationError'):
-            RegexValidator('[0-9]', custom_error_class=Exception)  # noqa
+            RegexValidator('[0-9]', custom_error_class=Exception)  # type: ignore[arg-type]  # noqa
 
     # Tests with length requirements
 

--- a/tests/validators/reject_validator_test.py
+++ b/tests/validators/reject_validator_test.py
@@ -80,7 +80,7 @@ class RejectValidatorTest:
     def test_allow_none():
         """ Test that RejectValidator allows None if allow_none is True. """
         validator = RejectValidator(allow_none=True)
-        assert validator.validate(None) is None
+        assert validator.validate(None) is None  # type: ignore[func-returns-value]
 
     # Tests with custom errors
 
@@ -180,4 +180,4 @@ class RejectValidatorTest:
         Test that RejectValidator raises an error on construction if the error class is not a ValidatonError subclass.
         """
         with pytest.raises(TypeError, match='Error class must be a subclass of ValidationError'):
-            RejectValidator(error_class=Exception)  # noqa
+            RejectValidator(error_class=Exception)  # type: ignore[arg-type]  # noqa

--- a/tests/validators/validator_test.py
+++ b/tests/validators/validator_test.py
@@ -24,7 +24,7 @@ class ValidatorTest:
         # Ensure that Validator creation causes a DeprecationWarning
         with pytest.deprecated_call():
             class ValidatorWithoutKwargs(Validator):
-                def validate(self, input_data: Any) -> Any:  # noqa (missing parameter)
+                def validate(self, input_data: Any) -> Any:  # type: ignore[override]  # noqa
                     return input_data
 
         # Check that validate_with_context() calls validate() without errors

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,7 @@ deps = flake8
 commands = flake8 src/ tests/
 
 [testenv:mypy,py{312,311,310,39,38}-mypy]
-skip_install = true
-deps = mypy
+extras = testing
 commands = mypy
 
 [testenv:clean]


### PR DESCRIPTION
This is a follow up PR to #120, which solves another part of #116.

It adds the unit tests to the targets of mypy and fixes typing issues in those files.

There are two rules that are ignored for now:

1. Untyped definitions are allowed in the unit tests, e.g. you don't need to specify parameter types and the return type for test functions (`def test_something(input_data):` is sufficient). This is because a) the return type is always `None` anyway, and b) for a lot of the test parameters it would make sense to use `Any` anyway.
2. `assignment` errors are ignored. This is the main issue of using validataclass and mypy in a project. Defining a validataclass with e.g. `foo: int = IntegerValidator()` will result in a type error, because mypy thinks we assign an `IntegerValidator` object to an attribute that has the type `int`. To solve this, we probably need a custom mypy-validataclass integration, which will be the main and last part of #116.