### PR TITLE
Move python-dateutil to testing requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     typing-extensions ~= 4.3
-    python-dateutil
 
 [options.packages.find]
 where = src
@@ -46,4 +45,5 @@ testing =
     coverage-conditional-plugin ~= 0.5
     flake8 ~= 7.0
     mypy ~= 1.9
+    python-dateutil
     types-python-dateutil


### PR DESCRIPTION
The `dateutil` library is currently required by validataclass. However, it's only used in the unit tests, the library itself shouldn't depend on it.

This PR moves `python-dateutil` from install requirements to testing requirements.