### PR TITLE
Fix release pipeline by installing all testing requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,8 @@ jobs:
           name: dist_packages
           path: dist/
 
-      - name: Install test dependencies
-        run: pip install pytest pytest-cov
-
-      - name: Install built package
-        run: pip install dist/validataclass-*.whl
+      - name: Install built package with testing dependencies
+        run: pip install "$(find dist/ -name 'validataclass-*.whl')[testing]"
 
       - name: Run unit tests
         run: python -m pytest


### PR DESCRIPTION
The release pipeline broke after #122 because it doesn't install `dateutil` when running the unit tests before publishing the package.

This PR fixes this by installing all "testing" extra requirements in the release pipeline.