### PR TITLE
PEP 561 compatibility (py.typed) and explicit re-exports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: pip install --upgrade pip tox
 
-      - name: Run unit tests with tox
+      - name: Run test suite with tox
         # Run tox using the version of Python in `PATH`
         run: tox run -e clean,py,report,flake8,mypy -- --junit-xml=reports/pytest_${{ matrix.python-version }}.xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ explicit_package_bases = true
 # Enable strict type checking
 strict = true
 
-# Ignore errors like `Module "validataclass.exceptions" does not explicitly export attribute "..."`
-no_implicit_reexport = false
-
 [[tool.mypy.overrides]]
 module = 'tests.*'
 

--- a/src/validataclass/dataclasses/__init__.py
+++ b/src/validataclass/dataclasses/__init__.py
@@ -8,3 +8,13 @@ from .defaults import Default, DefaultFactory, DefaultUnset, NoDefault
 from .validataclass import validataclass
 from .validataclass_field import validataclass_field
 from .validataclass_mixin import ValidataclassMixin
+
+__all__ = [
+    'Default',
+    'DefaultFactory',
+    'DefaultUnset',
+    'NoDefault',
+    'ValidataclassMixin',
+    'validataclass',
+    'validataclass_field',
+]

--- a/src/validataclass/exceptions/__init__.py
+++ b/src/validataclass/exceptions/__init__.py
@@ -4,26 +4,34 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-# "Meta exceptions" (no validation errors, but logic errors in the validators, e.g. when specifying invalid options for
-# a validator)
+from .base_exceptions import ValidationError
+from .common_exceptions import (
+    FieldNotAllowedError,
+    InvalidTypeError,
+    RequiredValueError,
+)
+from .dataclass_exceptions import DataclassPostValidationError
+from .datetime_exceptions import (
+    DateTimeRangeError,
+    InvalidDateError,
+    InvalidDateTimeError,
+    InvalidTimeError,
+)
+from .dict_exceptions import (
+    DictFieldsValidationError,
+    DictInvalidKeyTypeError,
+    DictRequiredFieldError,
+)
+from .email_exceptions import InvalidEmailError
+from .list_exceptions import (
+    ListItemsValidationError,
+    ListLengthError,
+)
 from .meta_exceptions import (
     DataclassInvalidPreValidateSignatureException,
     DataclassValidatorFieldException,
     InvalidValidatorOptionException,
 )
-
-# Base exception classes for validation errors
-from .base_exceptions import ValidationError
-
-# Common validation errors used throughout the library
-from .common_exceptions import RequiredValueError, FieldNotAllowedError, InvalidTypeError
-
-# More specific validation errors
-from .dataclass_exceptions import DataclassPostValidationError
-from .datetime_exceptions import InvalidDateError, InvalidTimeError, InvalidDateTimeError, DateTimeRangeError
-from .dict_exceptions import DictFieldsValidationError, DictInvalidKeyTypeError, DictRequiredFieldError
-from .email_exceptions import InvalidEmailError
-from .list_exceptions import ListItemsValidationError, ListLengthError
 from .misc_exceptions import ValueNotAllowedError
 from .number_exceptions import (
     DecimalPlacesError,
@@ -40,3 +48,36 @@ from .string_exceptions import (
     StringTooShortError,
 )
 from .url_exceptions import InvalidUrlError
+
+__all__ = [
+    'DataclassInvalidPreValidateSignatureException',
+    'DataclassPostValidationError',
+    'DataclassValidatorFieldException',
+    'DateTimeRangeError',
+    'DecimalPlacesError',
+    'DictFieldsValidationError',
+    'DictInvalidKeyTypeError',
+    'DictRequiredFieldError',
+    'FieldNotAllowedError',
+    'InvalidDateError',
+    'InvalidDateTimeError',
+    'InvalidDecimalError',
+    'InvalidEmailError',
+    'InvalidIntegerError',
+    'InvalidTimeError',
+    'InvalidTypeError',
+    'InvalidUrlError',
+    'InvalidValidatorOptionException',
+    'ListItemsValidationError',
+    'ListLengthError',
+    'NonFiniteNumberError',
+    'NumberRangeError',
+    'RegexMatchError',
+    'RequiredValueError',
+    'StringInvalidCharactersError',
+    'StringInvalidLengthError',
+    'StringTooLongError',
+    'StringTooShortError',
+    'ValidationError',
+    'ValueNotAllowedError',
+]

--- a/src/validataclass/helpers/__init__.py
+++ b/src/validataclass/helpers/__init__.py
@@ -4,17 +4,34 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
+# Requirements for the __getattr__ definition below
 import importlib
 import warnings
 from typing import Any
 
-from .datetime_range import BaseDateTimeRange, DateTimeRange, DateTimeOffsetRange
-from .unset_value import UnsetValue, UnsetValueType, OptionalUnset, OptionalUnsetNone, unset_to_none
+# Re-export symbols from modules
+from .datetime_range import (
+    BaseDateTimeRange,
+    DateTimeOffsetRange,
+    DateTimeRange,
+)
+from .unset_value import (
+    OptionalUnset,
+    OptionalUnsetNone,
+    UnsetValue,
+    UnsetValueType,
+    unset_to_none,
+)
 
-# Defining __all__ is necessary here because of the definition of __getattr__() below.
 __all__ = [
-    'BaseDateTimeRange', 'DateTimeRange', 'DateTimeOffsetRange',
-    'UnsetValue', 'UnsetValueType', 'OptionalUnset', 'OptionalUnsetNone', 'unset_to_none',
+    'BaseDateTimeRange',
+    'DateTimeOffsetRange',
+    'DateTimeRange',
+    'OptionalUnset',
+    'OptionalUnsetNone',
+    'UnsetValue',
+    'UnsetValueType',
+    'unset_to_none',
 ]
 
 

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -4,10 +4,6 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-# Abstract base class
-from .validator import Validator
-
-# Validators
 from .allow_empty_string import AllowEmptyString
 from .any_of_validator import AnyOfValidator
 from .anything_validator import AnythingValidator
@@ -33,3 +29,38 @@ from .reject_validator import RejectValidator
 from .string_validator import StringValidator
 from .time_validator import TimeValidator, TimeFormat
 from .url_validator import UrlValidator
+from .validator import Validator
+
+__all__ = [
+    'AllowEmptyString',
+    'AnyOfValidator',
+    'AnythingValidator',
+    'BigIntegerValidator',
+    'BooleanValidator',
+    'DataclassValidator',
+    'DateTimeFormat',
+    'DateTimeValidator',
+    'DateValidator',
+    'DecimalValidator',
+    'DictValidator',
+    'DiscardValidator',
+    'EmailValidator',
+    'EnumValidator',
+    'FloatToDecimalValidator',
+    'FloatValidator',
+    'IntegerValidator',
+    'ListValidator',
+    'NoneToUnsetValue',
+    'Noneable',
+    'NumericValidator',
+    'RegexValidator',
+    'RejectValidator',
+    'StringValidator',
+    'T_Dataclass',
+    'T_Enum',
+    'T_ListItem',
+    'TimeFormat',
+    'TimeValidator',
+    'UrlValidator',
+    'Validator',
+]

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -4,6 +4,10 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
+# Abstract base class (needs to be imported first to avoid import loops)
+from .validator import Validator  # isort:skip
+
+# Validators
 from .allow_empty_string import AllowEmptyString
 from .any_of_validator import AnyOfValidator
 from .anything_validator import AnythingValidator
@@ -11,7 +15,7 @@ from .big_integer_validator import BigIntegerValidator
 from .boolean_validator import BooleanValidator
 from .dataclass_validator import DataclassValidator, T_Dataclass
 from .date_validator import DateValidator
-from .datetime_validator import DateTimeValidator, DateTimeFormat
+from .datetime_validator import DateTimeFormat, DateTimeValidator
 from .decimal_validator import DecimalValidator
 from .dict_validator import DictValidator
 from .discard_validator import DiscardValidator
@@ -27,9 +31,8 @@ from .numeric_validator import NumericValidator
 from .regex_validator import RegexValidator
 from .reject_validator import RejectValidator
 from .string_validator import StringValidator
-from .time_validator import TimeValidator, TimeFormat
+from .time_validator import TimeFormat, TimeValidator
 from .url_validator import UrlValidator
-from .validator import Validator
 
 __all__ = [
     'AllowEmptyString',

--- a/tests/dataclasses/validataclass_test.py
+++ b/tests/dataclasses/validataclass_test.py
@@ -3,6 +3,8 @@ validataclass
 Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
+# (Ignore comparison-overlap errors, which happen in comparisons like `assert fields['baz'].type is Optional[str]`)
+# mypy: no-strict-equality
 
 import dataclasses
 from typing import Dict, List, Optional, Union


### PR DESCRIPTION
This PR is another small step towards full mypy support (#116).

It adds the `py.typed` file to make the package PEP 561 compatible (if this file is present, type checkers know that the library is properly typed and can rely on its type annotations).

It also introduces explicit re-exports in `__init__.py` files using the `__all__` variable. This is necessary to enable the `no-implicit-reexport` mypy rule, not just for running mypy on the library itself, but also for projects that use validataclass. It's also just cleaner to explicitly re-export everything.

I also had to add a rule exception to one of the unit test files because mypy reported errors for it. I'm not sure why these errors only popped up now, though.