### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
 
     steps:
       - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.5.1
-envlist = clean,py{312,311,310},report,flake8,mypy
+envlist = clean,py{313,312,311,310},report,flake8,mypy
 skip_missing_interpreters = true
 
 [flake8]
@@ -20,13 +20,13 @@ commands = python -m pytest --cov --cov-append {posargs}
 [testenv:flake8]
 commands = flake8 src/ tests/
 
-[testenv:mypy,py{312,311,310}-mypy]
+[testenv:mypy,py{313,312,311,310}-mypy]
 commands = mypy
 
 [testenv:clean]
 commands = coverage erase
 
-[testenv:report,py{312,311,310}-report]
+[testenv:report,py{313,312,311,310}-report]
 commands =
     coverage html
     coverage report --fail-under=100


### PR DESCRIPTION
This PR adds official support for Python 3.13.

No code changes were needed, the PR only adds Python 3.13 as a target version to the test suites.

While running the tests locally, I also noticed and fixed a small issue in the Makefile that was introduced in 0cb18fae19990d5ec4ca398b563a5ccc9af39912: The `docker-test-*` and similar targets ignored the individual `TOX_ARGS` settings and always used the full list of tests defined for the `docker-tox` target. The solution was to add a separate base target that doesn't define the variable.