### PR TITLE
Generic-based typing for Validator classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ docker-tox: TOX_ARGS='-e clean,py313,py312,py311,py310,report,flake8,py313-mypy'
 docker-tox: _docker-tox
 
 # Run partial tox test suites in Docker
-.PHONY: docker-tox-py313 docker-tox-py312 docker-tox-py311 docker-tox-py310
+.PHONY: docker-test-py313 docker-test-py312 docker-test-py311 docker-test-py310
 docker-test-py313: TOX_ARGS="-e clean,py313,py313-report"
 docker-test-py313: _docker-tox
 docker-test-py312: TOX_ARGS="-e clean,py312,py312-report"

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,11 @@ venv-tox:
 test:
 	tox run -e clean,py,report
 
+# Only run pytest, but limited to the type checker tests in `tests/mypy`.
+.PHONY: test
+test-typing:
+	tox run -e pytest-mypy
+
 # Only run flake8 linter
 .PHONY: flake8
 flake8:

--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -12,14 +12,7 @@ of the data types that we cover here.
 
 ## Quick overview
 
-There are at least two ways to categorize the existing validator classes.
-
-One distinction would be "base types" vs. "extended types": Base types are all validators that do **not** extend an existing validator,
-i.e. they directly implement the `Validator` base class. Examples for base type validators would be `StringValidator`, `IntegerValidator`
-and `DictValidator`. Extended types are all validators that **do** extend existing validators, e.g. `DecimalValidator` is based on
-`StringValidator`.
-
-A much more useful distinction is to categorize the validators according to their function:
+The validators provided by the library can be roughly categorized based on their functionality and purpose:
 
 - Boolean types:
   - `BooleanValidator`: Validates boolean values (`True` / `False`, optionally allowing strings `"true"` / `"false"`)
@@ -59,7 +52,6 @@ A much more useful distinction is to categorize the validators according to thei
   - `RejectValidator`: Rejects any input with a validation error (except for `None` if allowed)
   - `DiscardValidator`: Discards any input and returns a predefined value
   - `AllowEmptyString`: Wraps another validator but allows the input to be empty string `('')`
-
 
 These are a lot of different validators (and there will be even more in future versions) and many of them have a lot of parameters, so we
 will not cover all of them here in detail.

--- a/docs/05-dataclasses.md
+++ b/docs/05-dataclasses.md
@@ -167,12 +167,12 @@ _Let me tell you about the `DataclassValidator`._
 
 ## The DataclassValidator
 
-The `DataclassValidator` basically is just a very specialized `DictValidator`. It validates dictionaries using **field validators**,
-and then converts the validated dictionaries to objects of a specified **dataclass**.
+The `DataclassValidator` validates dictionaries using **field validators** similar to the `DictValidator` and then
+converts the validated dictionaries to objects of a specified **dataclass**.
 
-But instead of specifying the field validators in the validator, you can now define the validators directly inside the dataclass.
-The `DataclassValidator` will read these field validators from the dataclass and pass them to the underlying `DictValidator`. In the
-same way it also determines which fields are required and which are optional.
+But instead of specifying the field validators in the validator, you can now define the validators directly inside the
+dataclass. The `DataclassValidator` will read these field validators from the dataclass and use them to validate the
+input dictionary. In the same way it also determines which fields are required and which are optional.
 
 The usage of the `DataclassValidator` then is pretty trivial, assuming we have already defined the dataclass:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,8 @@ addopts =
     --import-mode=importlib
     --cov-context=test
     --cov-report=
+    --mypy-ini-file=tests/mypy/pytest_mypy.ini
+    --mypy-only-local-stub
 
 testpaths = tests
 python_files = *_test.py *Test.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ where = src
 testing =
     pytest ~= 8.4
     pytest-cov ~= 6.2
+    pytest-mypy-plugins ~= 3.2
     coverage ~= 7.9
     flake8 ~= 7.3
     mypy ~= 1.17

--- a/src/validataclass/dataclasses/validataclass.py
+++ b/src/validataclass/dataclasses/validataclass.py
@@ -193,7 +193,7 @@ def _get_existing_validator_fields(cls: type[_T]) -> dict[str, _ValidatorField]:
     return validator_fields
 
 
-def _parse_validator_tuple(args: tuple[Any, ...] | Validator | Default | None) -> _ValidatorField:
+def _parse_validator_tuple(args: tuple[Any, ...] | Validator[Any] | Default | None) -> _ValidatorField:
     """
     Parses field arguments (the value of a field in a dataclass that has not been parsed by `@dataclass` yet) to a
     tuple of a Validator and a Default object.

--- a/src/validataclass/dataclasses/validataclass_field.py
+++ b/src/validataclass/dataclasses/validataclass_field.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 def validataclass_field(
-    validator: Validator,
+    validator: Validator[Any],
     default: Any = NoDefault,
     *,
     metadata: dict[str, Any] | None = None,

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -5,7 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 # Abstract base class (needs to be imported first to avoid import loops)
-from .validator import T_Validated, Validator  # isort:skip
+from .validator import Validator  # isort:skip
 
 # Validators
 from .allow_empty_string import AllowEmptyString
@@ -13,18 +13,18 @@ from .any_of_validator import AnyOfValidator
 from .anything_validator import AnythingValidator
 from .big_integer_validator import BigIntegerValidator
 from .boolean_validator import BooleanValidator
-from .dataclass_validator import DataclassValidator, T_Dataclass
+from .dataclass_validator import DataclassValidator
 from .date_validator import DateValidator
 from .datetime_validator import DateTimeFormat, DateTimeValidator
 from .decimal_validator import DecimalValidator
 from .dict_validator import DictValidator
 from .discard_validator import DiscardValidator
 from .email_validator import EmailValidator
-from .enum_validator import EnumValidator, T_Enum
+from .enum_validator import EnumValidator
 from .float_to_decimal_validator import FloatToDecimalValidator
 from .float_validator import FloatValidator
 from .integer_validator import IntegerValidator
-from .list_validator import ListValidator, T_ListItem
+from .list_validator import ListValidator
 from .none_to_unset_value import NoneToUnsetValue
 from .noneable import Noneable
 from .numeric_validator import NumericValidator
@@ -33,6 +33,14 @@ from .reject_validator import RejectValidator
 from .string_validator import StringValidator
 from .time_validator import TimeFormat, TimeValidator
 from .url_validator import UrlValidator
+
+# Using the following TypeVars outside of the modules they were defined in is deprecated. You should define your own
+# TypeVars if needed. They are still imported here for compatibility, but they won't be exported in __all__, so that
+# linting tools will complain about it.
+# TODO: Deprecated. Remove imports in future version.
+from .dataclass_validator import T_Dataclass  # noqa  # isort:skip
+from .enum_validator import T_Enum  # noqa  # isort:skip
+from .list_validator import T_ListItem  # noqa  # isort:skip
 
 __all__ = [
     'AllowEmptyString',
@@ -59,10 +67,6 @@ __all__ = [
     'RegexValidator',
     'RejectValidator',
     'StringValidator',
-    'T_Dataclass',
-    'T_Enum',
-    'T_ListItem',
-    'T_Validated',
     'TimeFormat',
     'TimeValidator',
     'UrlValidator',

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -5,7 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 # Abstract base class (needs to be imported first to avoid import loops)
-from .validator import Validator  # isort:skip
+from .validator import T_Validated, Validator  # isort:skip
 
 # Validators
 from .allow_empty_string import AllowEmptyString
@@ -62,6 +62,7 @@ __all__ = [
     'T_Dataclass',
     'T_Enum',
     'T_ListItem',
+    'T_Validated',
     'TimeFormat',
     'TimeValidator',
     'UrlValidator',

--- a/src/validataclass/validators/any_of_validator.py
+++ b/src/validataclass/validators/any_of_validator.py
@@ -6,7 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 import warnings
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, TypeVar
 
 from validataclass.exceptions import ValueNotAllowedError, InvalidValidatorOptionException
 from .validator import Validator
@@ -15,8 +15,11 @@ __all__ = [
     'AnyOfValidator',
 ]
 
+# Type parameter for the allowed values of an AnyOfValidator
+T_AnyOfValues = TypeVar('T_AnyOfValues')
 
-class AnyOfValidator(Validator):
+
+class AnyOfValidator(Validator[T_AnyOfValues]):
     """
     Validator that checks an input value against a specified list of allowed values. If the value is contained in the
     list, the value is returned.
@@ -59,7 +62,7 @@ class AnyOfValidator(Validator):
     max_allowed_values_in_validation_error: int = 20
 
     # Values allowed as input
-    allowed_values: list[Any]
+    allowed_values: list[T_AnyOfValues]
 
     # Types allowed for input data (set by parameter or autodetermined from allowed_values)
     allowed_types: list[type]
@@ -67,9 +70,11 @@ class AnyOfValidator(Validator):
     # If set, strings will be matched case-sensitively
     case_sensitive: bool = False
 
+    # TODO: Improve typing: If allowed_types is set, T_AnyOfValues could be narrowed down. This is difficult without an
+    #   intersection type though, but maybe it can be done in the validataclass mypy plugin.
     def __init__(
         self,
-        allowed_values: Iterable[Any],
+        allowed_values: Iterable[T_AnyOfValues],
         *,
         allowed_types: Iterable[type] | type | None = None,
         case_sensitive: bool | None = None,
@@ -120,7 +125,7 @@ class AnyOfValidator(Validator):
         # Set case_sensitive parameter, defaulting to False.
         self.case_sensitive = case_sensitive if case_sensitive is not None else False
 
-    def validate(self, input_data: Any, **kwargs: Any) -> Any:
+    def validate(self, input_data: Any, **kwargs: Any) -> T_AnyOfValues:
         """
         Validate that input is in the list of allowed values. Returns the value (as defined in the list).
         """

--- a/src/validataclass/validators/any_of_validator.py
+++ b/src/validataclass/validators/any_of_validator.py
@@ -124,10 +124,6 @@ class AnyOfValidator(Validator):
         """
         Validate that input is in the list of allowed values. Returns the value (as defined in the list).
         """
-        # Special case to allow None as value if None is in the allowed_values list (bypasses _ensure_type())
-        if None in self.allowed_values and input_data is None:
-            return None
-
         # Ensure type is one of the allowed types (set by parameter or autodetermined from allowed_values)
         self._ensure_type(input_data, self.allowed_types)
 

--- a/src/validataclass/validators/boolean_validator.py
+++ b/src/validataclass/validators/boolean_validator.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-class BooleanValidator(Validator):
+class BooleanValidator(Validator[bool]):
     """
     Validator for boolean values (`True` and `False`).
 

--- a/src/validataclass/validators/dataclass_validator.py
+++ b/src/validataclass/validators/dataclass_validator.py
@@ -29,7 +29,7 @@ __all__ = [
 T_Dataclass = TypeVar('T_Dataclass', bound=object)
 
 
-class DataclassValidator(Generic[T_Dataclass], DictValidator):
+class DataclassValidator(DictValidator, Generic[T_Dataclass]):
     """
     Validator that converts dictionaries to instances of user-defined dataclasses with validated fields.
 

--- a/src/validataclass/validators/dataclass_validator.py
+++ b/src/validataclass/validators/dataclass_validator.py
@@ -22,7 +22,6 @@ from .validator import Validator
 
 __all__ = [
     'DataclassValidator',
-    'T_Dataclass',
 ]
 
 # Type parameter for an instance of a dataclass

--- a/src/validataclass/validators/dataclass_validator.py
+++ b/src/validataclass/validators/dataclass_validator.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 import dataclasses
 import inspect
 import warnings
-from typing import Any, Generic, TypeGuard, TypeVar
+from typing import Any, Callable, TypeGuard, TypeVar
 
 from validataclass.dataclasses import Default, NoDefault
 from validataclass.exceptions import (
@@ -25,22 +25,23 @@ __all__ = [
     'T_Dataclass',
 ]
 
-# Type variable for an instance of a dataclass
+# Type parameter for an instance of a dataclass
 T_Dataclass = TypeVar('T_Dataclass', bound=object)
 
 
-class DataclassValidator(DictValidator, Generic[T_Dataclass]):
+class DataclassValidator(Validator[T_Dataclass]):
     """
     Validator that converts dictionaries to instances of user-defined dataclasses with validated fields.
 
-    The DataclassValidator is basically a specialized variant of the DictValidator that takes a dataclass with special
-    metadata as parameter, which it uses to determine the dictionary fields, which validators to use for validating
-    them, which fields are required or optional, and what default values to use for optional fields. Input data is first
-    validated as a regular dictionary and then used to create an instance of the dataclass.
+    The DataclassValidator requires a dataclass with special metadata that defines which validators to use for which
+    fields, whether they are required or optional and what default values to use for optional fields.
 
     While you *can* define this metadata manually using the built-in Python dataclass function `dataclasses.field()`,
     it is highly recommended to use the helpers provided by this library, i.e. the decorator `@validataclass` and (if
     necessary) the function `validataclass_field()`.
+
+    NOTE: As of now, the DataclassValidator internally uses a DictValidator to do the initial validation of the raw
+    dictionary. Please note that this is an implementation detail that might/will change in the future.
 
     Example:
 
@@ -106,6 +107,9 @@ class DataclassValidator(DictValidator, Generic[T_Dataclass]):
     ```
     """
 
+    # Base validator to validate the input as a dictionary first
+    dict_validator: DictValidator[Any]
+
     # Dataclass type that the validated dictionary will be converted to
     dataclass_cls: type[T_Dataclass]
 
@@ -152,11 +156,11 @@ class DataclassValidator(DictValidator, Generic[T_Dataclass]):
             if field_default is NoDefault:
                 required_fields.append(field.name)
 
-        # Initialize the underlying DictValidator
-        super().__init__(field_validators=field_validators, required_fields=required_fields)
+        # Initialize the DictValidator
+        self.dict_validator = DictValidator(field_validators=field_validators, required_fields=required_fields)
 
     @staticmethod
-    def _get_field_validator(field: dataclasses.Field[Any]) -> Validator:
+    def _get_field_validator(field: dataclasses.Field[Any]) -> Validator[Any]:
         # Parse field metadata to get Validator
         validator = field.metadata.get('validator')
 
@@ -192,7 +196,7 @@ class DataclassValidator(DictValidator, Generic[T_Dataclass]):
         Pre-validation steps: Validates the input as a dictionary and fills in the default values.
         """
         # Custom pre-validation using the __pre_validate__() method (class or static) in the dataclass (if defined)
-        pre_validate_func = getattr(self.dataclass_cls, '__pre_validate__', None)
+        pre_validate_func: Callable[..., Any] | None = getattr(self.dataclass_cls, '__pre_validate__', None)
         if pre_validate_func is not None:
             # Ensure type before calling the DictValidator to make sure __pre_validate__ gets a dict
             self._ensure_type(input_data, dict)
@@ -223,8 +227,8 @@ class DataclassValidator(DictValidator, Generic[T_Dataclass]):
             # Filter input dictionary through __pre_validate__()
             input_data = pre_validate_func(input_data, **context_kwargs)
 
-        # Validate raw dictionary using underlying DictValidator
-        validated_dict = super().validate(input_data, **kwargs)
+        # Validate raw dictionary using DictValidator
+        validated_dict = self.dict_validator.validate(input_data, **kwargs)
 
         # Fill optional fields with default values
         for field_name, field_default in self.field_defaults.items():
@@ -233,7 +237,7 @@ class DataclassValidator(DictValidator, Generic[T_Dataclass]):
 
         return validated_dict
 
-    def validate(self, input_data: Any, **kwargs: Any) -> T_Dataclass:  # type: ignore[override]
+    def validate(self, input_data: Any, **kwargs: Any) -> T_Dataclass:
         """
         Validate an input dictionary according to the specified dataclass. Returns an instance of the dataclass.
         """

--- a/src/validataclass/validators/date_validator.py
+++ b/src/validataclass/validators/date_validator.py
@@ -9,13 +9,14 @@ from typing import Any
 
 from validataclass.exceptions import InvalidDateError
 from .string_validator import StringValidator
+from .validator import Validator
 
 __all__ = [
     'DateValidator',
 ]
 
 
-class DateValidator(StringValidator):
+class DateValidator(Validator[date]):
     """
     Validator that parses date strings in `YYYY-MM-DD` format (e.g. `2021-01-31`) to `datetime.date` objects.
 
@@ -33,6 +34,9 @@ class DateValidator(StringValidator):
     Output: `datetime.date`
     """
 
+    # Base validator to parse input as a string first
+    string_validator: StringValidator
+
     def __init__(self) -> None:
         """
         Creates a `DateValidator`.
@@ -40,14 +44,14 @@ class DateValidator(StringValidator):
         No parameters.
         """
         # Initialize StringValidator without any parameters
-        super().__init__()
+        self.string_validator = StringValidator()
 
-    def validate(self, input_data: Any, **kwargs: Any) -> date:  # type: ignore[override]
+    def validate(self, input_data: Any, **kwargs: Any) -> date:
         """
         Validates input as a valid date string and convert it to a `datetime.date` object.
         """
         # First, validate input data as string
-        date_string = super().validate(input_data, **kwargs)
+        date_string = self.string_validator.validate(input_data, **kwargs)
 
         # Try to create date object from string (only accepts "YYYY-MM-DD")
         try:

--- a/src/validataclass/validators/dict_validator.py
+++ b/src/validataclass/validators/dict_validator.py
@@ -4,7 +4,7 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from validataclass.exceptions import (
     DictFieldsValidationError,
@@ -19,8 +19,11 @@ __all__ = [
     'DictValidator',
 ]
 
+# Type parameter for the values of the validated dictionary
+T_DictValues = TypeVar('T_DictValues')
 
-class DictValidator(Validator):
+
+class DictValidator(Validator[dict[str, T_DictValues]], Generic[T_DictValues]):
     """
     Validator for dictionaries with all kinds of data.
 
@@ -66,10 +69,10 @@ class DictValidator(Validator):
     """
 
     # Dictionary to specify which validators are applied to which fields of the input dictionary
-    field_validators: dict[str, Validator]
+    field_validators: dict[str, Validator[T_DictValues]]
 
     # Validator that is applied to all fields not specified in field_validators
-    default_validator: Validator | None
+    default_validator: Validator[T_DictValues] | None
 
     # Set of required fields
     required_fields: set[str]
@@ -77,8 +80,8 @@ class DictValidator(Validator):
     def __init__(
         self,
         *,
-        field_validators: dict[str, Validator] | None = None,
-        default_validator: Validator | None = None,
+        field_validators: dict[str, Validator[T_DictValues]] | None = None,
+        default_validator: Validator[T_DictValues] | None = None,
         required_fields: list[str] | None = None,
         optional_fields: list[str] | None = None
     ):
@@ -132,7 +135,7 @@ class DictValidator(Validator):
         if optional_fields is not None:
             self.required_fields = self.required_fields - set(optional_fields)
 
-    def validate(self, input_data: Any, **kwargs: Any) -> dict[str, Any]:
+    def validate(self, input_data: Any, **kwargs: Any) -> dict[str, T_DictValues]:
         """
         Validates input data. Returns a validated dict.
         """

--- a/src/validataclass/validators/discard_validator.py
+++ b/src/validataclass/validators/discard_validator.py
@@ -5,7 +5,9 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from copy import deepcopy
-from typing import Any
+from typing import Any, overload
+
+from typing_extensions import TypeVar
 
 from .validator import Validator
 
@@ -13,8 +15,11 @@ __all__ = [
     'DiscardValidator',
 ]
 
+# Type parameter for the output value of the DiscardValidator
+T_DiscardOutput = TypeVar('T_DiscardOutput', default=None)
 
-class DiscardValidator(Validator):
+
+class DiscardValidator(Validator[T_DiscardOutput]):
     """
     Special validator that discards any input and always returns a predefined value.
 
@@ -42,7 +47,15 @@ class DiscardValidator(Validator):
     """
 
     # Value that is returned by the validator
-    output_value: Any
+    output_value: T_DiscardOutput
+
+    @overload
+    def __init__(self, *, output_value: None = None):
+        ...
+
+    @overload
+    def __init__(self, *, output_value: T_DiscardOutput):
+        ...
 
     def __init__(self, *, output_value: Any = None):
         """
@@ -53,7 +66,7 @@ class DiscardValidator(Validator):
         """
         self.output_value = output_value
 
-    def validate(self, input_data: Any, **kwargs: Any) -> Any:
+    def validate(self, input_data: Any, **kwargs: Any) -> T_DiscardOutput:
         """
         Validates input data.
         Discards any input and always returns `None` (or the specified `output_value`).

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -14,7 +14,6 @@ from .validator import Validator
 
 __all__ = [
     'EnumValidator',
-    'T_Enum',
 ]
 
 # Type variable for type hints in EnumValidator

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -20,7 +20,7 @@ __all__ = [
 T_Enum = TypeVar('T_Enum', bound=Enum)
 
 
-class EnumValidator(Generic[T_Enum], AnyOfValidator):
+class EnumValidator(AnyOfValidator, Generic[T_Enum]):
     """
     Validator that uses an Enum class to parse input values to members of that enumeration.
 

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -6,10 +6,11 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 from validataclass.exceptions import InvalidValidatorOptionException, ValueNotAllowedError
 from .any_of_validator import AnyOfValidator
+from .validator import Validator
 
 __all__ = [
     'EnumValidator',
@@ -20,12 +21,12 @@ __all__ = [
 T_Enum = TypeVar('T_Enum', bound=Enum)
 
 
-class EnumValidator(AnyOfValidator, Generic[T_Enum]):
+class EnumValidator(Validator[T_Enum]):
     """
     Validator that uses an Enum class to parse input values to members of that enumeration.
 
-    This validator is based on the `AnyOfValidator`, using the Enum the get the list of allowed values and additionally
-    converting the raw values to Enum members after validation.
+    This validator uses an `AnyOfValidator` to check that the input value is one of the possible values of the Enum,
+    and then converts the raw value to the corresponding Enum member.
 
     By default all values in the Enum are accepted as input. This can be optionally restricted by specifying the
     `allowed_values` parameter, which will override the list of allowed values. This parameter can be specified using
@@ -69,6 +70,9 @@ class EnumValidator(AnyOfValidator, Generic[T_Enum]):
     Output: Member of specified Enum class
     """
 
+    # Validator to check whether the input is one of the allowed enum values
+    any_of_validator: AnyOfValidator[Any]
+
     # Enum class used to determine the list of allowed values
     enum_cls: type[T_Enum]
 
@@ -111,7 +115,7 @@ class EnumValidator(AnyOfValidator, Generic[T_Enum]):
             any_of_values = enum_values
 
         # Initialize base AnyOfValidator
-        super().__init__(
+        self.any_of_validator = AnyOfValidator(
             allowed_values=any_of_values,
             allowed_types=allowed_types,
             case_sensitive=case_sensitive,
@@ -123,7 +127,7 @@ class EnumValidator(AnyOfValidator, Generic[T_Enum]):
         Validates input to be a valid value of the specified Enum. Returns the Enum member.
         """
         # Validate input using the AnyOfValidator first
-        input_data = super().validate(input_data, **kwargs)
+        input_data = self.any_of_validator.validate(input_data, **kwargs)
 
         # Try to convert value to enum member
         try:

--- a/src/validataclass/validators/float_to_decimal_validator.py
+++ b/src/validataclass/validators/float_to_decimal_validator.py
@@ -113,7 +113,7 @@ class FloatToDecimalValidator(DecimalValidator):
         if allow_strings:
             self.allowed_types.append(str)
 
-    def validate(self, input_data: Any, **kwargs: Any) -> Decimal:  # type: ignore[override]
+    def validate(self, input_data: Any, **kwargs: Any) -> Decimal:
         """
         Validates input data as a float (optionally also as integer or string), then converts it to a `Decimal` object.
         """

--- a/src/validataclass/validators/float_validator.py
+++ b/src/validataclass/validators/float_validator.py
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 
-class FloatValidator(Validator):
+class FloatValidator(Validator[float]):
     """
     Validator for float values (IEEE 754), optionally with value range requirements.
 

--- a/src/validataclass/validators/integer_validator.py
+++ b/src/validataclass/validators/integer_validator.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-class IntegerValidator(Validator):
+class IntegerValidator(Validator[int]):
     """
     Validator for integer values, optionally with value range requirements.
 

--- a/src/validataclass/validators/list_validator.py
+++ b/src/validataclass/validators/list_validator.py
@@ -23,7 +23,7 @@ __all__ = [
 T_ListItem = TypeVar('T_ListItem')
 
 
-class ListValidator(Generic[T_ListItem], Validator):
+class ListValidator(Validator, Generic[T_ListItem]):
     """
     Validator for lists that validates list items with a specified item validator.
 

--- a/src/validataclass/validators/list_validator.py
+++ b/src/validataclass/validators/list_validator.py
@@ -19,11 +19,11 @@ __all__ = [
     'T_ListItem',
 ]
 
-# Type variable for type hints in DataclassValidator
+# Type parameter for the list items in the output of a ListValidator
 T_ListItem = TypeVar('T_ListItem')
 
 
-class ListValidator(Validator, Generic[T_ListItem]):
+class ListValidator(Validator[list[T_ListItem]], Generic[T_ListItem]):
     """
     Validator for lists that validates list items with a specified item validator.
 
@@ -68,7 +68,7 @@ class ListValidator(Validator, Generic[T_ListItem]):
     """
 
     # Validator used to validate the list items
-    item_validator: Validator
+    item_validator: Validator[T_ListItem]
 
     # List length constraints
     min_length: int | None = None
@@ -79,7 +79,7 @@ class ListValidator(Validator, Generic[T_ListItem]):
 
     def __init__(
         self,
-        item_validator: Validator,
+        item_validator: Validator[T_ListItem],
         *,
         min_length: int | None = None,
         max_length: int | None = None,

--- a/src/validataclass/validators/list_validator.py
+++ b/src/validataclass/validators/list_validator.py
@@ -16,7 +16,6 @@ from .validator import Validator
 
 __all__ = [
     'ListValidator',
-    'T_ListItem',
 ]
 
 # Type parameter for the list items in the output of a ListValidator

--- a/src/validataclass/validators/none_to_unset_value.py
+++ b/src/validataclass/validators/none_to_unset_value.py
@@ -4,7 +4,9 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from validataclass.helpers import UnsetValue
+from typing import TypeVar
+
+from validataclass.helpers import UnsetValue, UnsetValueType
 from .noneable import Noneable
 from .validator import Validator
 
@@ -12,8 +14,11 @@ __all__ = [
     'NoneToUnsetValue',
 ]
 
+# Type parameter for the validation result of the wrapped validator
+T_WrappedValidated = TypeVar('T_WrappedValidated')
 
-class NoneToUnsetValue(Noneable):
+
+class NoneToUnsetValue(Noneable[T_WrappedValidated, UnsetValueType]):
     """
     Shortcut variation of the `Noneable` wrapper, using `UnsetValue` as the default value.
 
@@ -37,7 +42,7 @@ class NoneToUnsetValue(Noneable):
     Output: `UnsetValue` or the output of the wrapped validator
     """
 
-    def __init__(self, validator: Validator):
+    def __init__(self, validator: Validator[T_WrappedValidated]):
         """
         Creates a NoneToUnsetValue wrapper for a specified validator.
         """

--- a/src/validataclass/validators/reject_validator.py
+++ b/src/validataclass/validators/reject_validator.py
@@ -4,7 +4,9 @@ Copyright (c) 2022, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Any, Never
+from typing import Any
+
+from typing_extensions import Never
 
 from validataclass.exceptions import ValidationError, FieldNotAllowedError
 from .validator import Validator

--- a/src/validataclass/validators/reject_validator.py
+++ b/src/validataclass/validators/reject_validator.py
@@ -4,7 +4,7 @@ Copyright (c) 2022, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import Any
+from typing import Any, Never
 
 from validataclass.exceptions import ValidationError, FieldNotAllowedError
 from .validator import Validator
@@ -14,7 +14,9 @@ __all__ = [
 ]
 
 
-class RejectValidator(Validator):
+# TODO: Deprecate the usage of `allow_none` because it complicates typing. If you need a validator that only accepts
+#   None and nothing else, you can use `Noneable(RejectValidator())`.
+class RejectValidator(Validator[Never]):
     """
     Special validator that rejects any input data with a validation error.
 
@@ -93,13 +95,14 @@ class RejectValidator(Validator):
         self.error_code = error_code
         self.error_reason = error_reason
 
-    def validate(self, input_data: Any, **kwargs: Any) -> None:
+    def validate(self, input_data: Any, **kwargs: Any) -> Never:
         """
         Validates input data. In this case, reject any value (except for `None` if `allow_none` is set).
         """
         # Accept None (if allowed)
         if self.allow_none and input_data is None:
-            return None
+            # TODO: Usage of allow_none should be deprecated, see above.
+            return None  # type: ignore[misc]
 
         # Reject any input
         raise self.error_class(code=self.error_code, reason=self.error_reason)

--- a/src/validataclass/validators/string_validator.py
+++ b/src/validataclass/validators/string_validator.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-class StringValidator(Validator):
+class StringValidator(Validator[str]):
     """
     Validator for arbitrary strings, optionally with minimal/maximal length requirements.
 

--- a/src/validataclass/validators/validator.py
+++ b/src/validataclass/validators/validator.py
@@ -83,16 +83,20 @@ class Validator(Generic[T_Validated], ABC):
 
     def _ensure_type(self, input_data: Any, expected_types: list[type] | type) -> None:
         """
-        Checks if input data is not `None` and has the expected type (or one of multiple expected types).
+        Checks the type of `input_data` against one or multiple expected types.
 
-        Raises `RequiredValueError` and `InvalidTypeError`.
+        If `type(None)` is not in the expected types, `_ensure_not_none(input_data)` will be called to ensure that the
+        input data is not `None`.
+
+        Raises `RequiredValueError` (only if input data is none) or `InvalidTypeError`.
         """
-        # Ensure input is not None
-        self._ensure_not_none(input_data)
-
         # Normalize expected_types to a list
         if not isinstance(expected_types, list):
             expected_types = [expected_types]
+
+        # Ensure input is not None (unless it's explicitly allowed)
+        if type(None) not in expected_types:
+            self._ensure_not_none(input_data)
 
         # Ensure input has correct type
         if type(input_data) not in expected_types:

--- a/src/validataclass/validators/validator.py
+++ b/src/validataclass/validators/validator.py
@@ -15,7 +15,6 @@ from validataclass.exceptions import InvalidTypeError, RequiredValueError
 
 __all__ = [
     'Validator',
-    'T_Validated',
 ]
 
 # Type parameter for the validated output of a validator

--- a/src/validataclass/validators/validator.py
+++ b/src/validataclass/validators/validator.py
@@ -9,14 +9,20 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Any
 
+from typing_extensions import Generic, TypeVar
+
 from validataclass.exceptions import InvalidTypeError, RequiredValueError
 
 __all__ = [
     'Validator',
+    'T_Validated',
 ]
 
+# Type parameter for the validated output of a validator
+T_Validated = TypeVar('T_Validated', covariant=True)
 
-class Validator(ABC):
+
+class Validator(Generic[T_Validated], ABC):
     """
     Base class for building extendable validator classes that validate, sanitize and transform input.
     """
@@ -33,7 +39,7 @@ class Validator(ABC):
         super().__init_subclass__(**kwargs)
 
     @abstractmethod
-    def validate(self, input_data: Any, **kwargs: Any) -> Any:
+    def validate(self, input_data: Any, **kwargs: Any) -> T_Validated:
         """
         Validates input data. Returns sanitized data or raises a `ValidationError` (or any subclass).
 
@@ -46,7 +52,7 @@ class Validator(ABC):
         """
         raise NotImplementedError()
 
-    def validate_with_context(self, input_data: Any, **kwargs: Any) -> Any:
+    def validate_with_context(self, input_data: Any, **kwargs: Any) -> T_Validated:
         """
         This method is a wrapper for `validate()` that always accepts arbitrary keyword arguments (which can be used
         for context-sensitive validation).

--- a/tests/mypy/pytest_mypy.ini
+++ b/tests/mypy/pytest_mypy.ini
@@ -1,0 +1,3 @@
+# This mypy config is used exclusively by the pytest-mypy-plugins plugin.
+[mypy]
+strict = true

--- a/tests/mypy/validators/test_allow_empty_string.yml
+++ b/tests/mypy/validators/test_allow_empty_string.yml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check inferred type parameters for AllowEmptyString (with implicit and explicit default='').
+- case: allow_empty_string_with_default_empty_string
+  main: |
+    from validataclass.validators import AllowEmptyString, IntegerValidator, Validator
+    validator = AllowEmptyString(IntegerValidator())
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    # Explicit default='' should result in the same type
+    reveal_type(AllowEmptyString(IntegerValidator(), default=''))
+    var1: AllowEmptyString[int, str] = validator  # correct
+    var2: AllowEmptyString[int, int] = validator  # error (8)
+    var3: Validator[int | str] = validator        # correct
+    var4: Validator[int] = validator              # error (10)
+    var5: Validator[str] = validator              # error (11)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.allow_empty_string.AllowEmptyString[builtins.int, builtins.str]"
+    main:4: note: Revealed type is "builtins.int | builtins.str"
+    main:6: note: Revealed type is "validataclass.validators.allow_empty_string.AllowEmptyString[builtins.int, builtins.str]"
+    main:8: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, str]", variable has type "AllowEmptyString[int, int]")  [assignment]
+    main:10: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, str]", variable has type "Validator[int]")  [assignment]
+    main:11: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, str]", variable has type "Validator[str]")  [assignment]
+
+# Check inferred type parameters for AllowEmptyString with a default value of the same type as the validator (e.g.
+# AllowEmptyString wrapping an IntegerValidator and converting the empty string to to 0).
+- case: allow_empty_string_with_default_of_same_type_as_validated
+  main: |
+    from validataclass.validators import AllowEmptyString, IntegerValidator, Validator
+    validator = AllowEmptyString(IntegerValidator(), default=0)
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: AllowEmptyString[int, int] = validator  # correct
+    var2: AllowEmptyString[int, str] = validator  # error (6)
+    var3: Validator[int] = validator              # correct
+    var4: Validator[str] = validator              # error (8)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.allow_empty_string.AllowEmptyString[builtins.int, builtins.int]"
+    main:4: note: Revealed type is "builtins.int"
+    main:6: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, int]", variable has type "AllowEmptyString[int, str]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, int]", variable has type "Validator[str]")  [assignment]
+
+# Check inferred type parameters for AllowEmptyString with a default value of a different type than the validator (e.g.
+# AllowEmptyString wrapping an IntegerValidator and converting the empty string to None).
+- case: allow_empty_string_with_default_of_different_type_as_validated
+  main: |
+    from validataclass.validators import AllowEmptyString, IntegerValidator, Validator
+    validator = AllowEmptyString(IntegerValidator(), default=None)
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: AllowEmptyString[int, None] = validator  # correct
+    var2: AllowEmptyString[int, str] = validator   # error (6)
+    var3: Validator[int | None] = validator        # correct
+    var4: Validator[int | str] = validator         # error (8)
+    var5: Validator[int] = validator               # error (9)
+    var6: Validator[None] = validator              # error (10)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.allow_empty_string.AllowEmptyString[builtins.int, None]"
+    main:4: note: Revealed type is "builtins.int | None"
+    main:6: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, None]", variable has type "AllowEmptyString[int, str]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, None]", variable has type "Validator[int | str]")  [assignment]
+    main:9: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, None]", variable has type "Validator[int]")  [assignment]
+    main:10: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, None]", variable has type "Validator[None]")  [assignment]

--- a/tests/mypy/validators/test_allow_empty_string.yml
+++ b/tests/mypy/validators/test_allow_empty_string.yml
@@ -23,7 +23,7 @@
     main:11: error: Incompatible types in assignment (expression has type "AllowEmptyString[int, str]", variable has type "Validator[str]")  [assignment]
 
 # Check inferred type parameters for AllowEmptyString with a default value of the same type as the validator (e.g.
-# AllowEmptyString wrapping an IntegerValidator and converting the empty string to to 0).
+# AllowEmptyString wrapping an IntegerValidator and converting the empty string to 0).
 - case: allow_empty_string_with_default_of_same_type_as_validated
   main: |
     from validataclass.validators import AllowEmptyString, IntegerValidator, Validator

--- a/tests/mypy/validators/test_any_of_validator.yml
+++ b/tests/mypy/validators/test_any_of_validator.yml
@@ -1,0 +1,80 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check inferred type parameters for AnyOfValidator with an empty list of allowed values.
+#
+# NOTE: There are no error cases here, i.e. no incompatible type parameters for Validator, because Never is the bottom
+# type and therefore a subset of every other (union of) type(s): int == int | Never, so Never is a subset of int, which
+# also means that a `Validator[Never]` is a valid `Validator[int]`. (In other words: a validator that never returns is
+# also a validator that only returns int/str/anything else.)
+- case: any_of_validator_with_empty_allowed_values
+  main: |
+    from typing import Never
+    from validataclass.validators import AnyOfValidator, Validator
+    reveal_type(AnyOfValidator(allowed_values=[]))
+    reveal_type(AnyOfValidator(allowed_values=[]).validate(42))
+    var1: AnyOfValidator[Never] = AnyOfValidator(allowed_values=[])  # correct
+    var2: AnyOfValidator[str] = AnyOfValidator(allowed_values=[])    # actually also correct
+    var3: Validator[Never] = AnyOfValidator(allowed_values=[])       # correct
+    var4: Validator[str] = AnyOfValidator(allowed_values=[])         # actually also correct
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.any_of_validator.AnyOfValidator[Never]"
+    main:4: note: Revealed type is "Never"
+
+# Check inferred type parameters for AnyOfValidator with a list of allowed values of a single type.
+- case: any_of_validator_with_int_allowed_values
+  main: |
+    from validataclass.validators import AnyOfValidator, Validator
+    validator = AnyOfValidator(allowed_values=[1, 2, 3])
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: AnyOfValidator[int] = validator  # correct
+    var2: AnyOfValidator[str] = validator  # error (6)
+    var3: Validator[int] = validator       # correct
+    var4: Validator[str] = validator       # error (8)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.any_of_validator.AnyOfValidator[builtins.int]"
+    main:4: note: Revealed type is "builtins.int"
+    main:6: error: Incompatible types in assignment (expression has type "AnyOfValidator[int]", variable has type "AnyOfValidator[str]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "AnyOfValidator[int]", variable has type "Validator[str]")  [assignment]
+
+# Check inferred type parameters for AnyOfValidator with a list of allowed values of mixed types, where the type of the
+# list is inferred from the list elements.
+#
+# NOTE: As of mypy 1.17, this allowed_values list will be inferred as "list[object]" rather than "list[int | str]".
+# That means you need to type the list explicitly if you want the AnyOfValidator type to be correctly inferred (see the
+# test "any_of_validator_with_mixed_allowed_values_explicit" below).
+# If that ever changes, this test case will fail, in which case this test and the other one should be adjusted.
+- case: any_of_validator_with_mixed_allowed_values_inferred
+  main: |
+    from validataclass.validators import AnyOfValidator, Validator
+    validator = AnyOfValidator(allowed_values=[1, 'foo'])
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: AnyOfValidator[object] = validator     # correct
+    var2: AnyOfValidator[int | str] = validator  # error (6)
+    var3: Validator[object] = validator          # correct
+    var4: Validator[int | str] = validator       # error (8)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.any_of_validator.AnyOfValidator[builtins.object]"
+    main:4: note: Revealed type is "builtins.object"
+    main:6: error: Incompatible types in assignment (expression has type "AnyOfValidator[object]", variable has type "AnyOfValidator[int | str]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "AnyOfValidator[object]", variable has type "Validator[int | str]")  [assignment]
+
+# Check inferred type parameters for AnyOfValidator with a list of allowed values of mixed types, where the type of the
+# list is explictly specified with a union of all list element types. (See note of the test above.)
+- case: any_of_validator_with_mixed_allowed_values_explicit
+  main: |
+    from validataclass.validators import AnyOfValidator, Validator
+    allowed_values: list[int | str] = [1, 'foo']
+    validator = AnyOfValidator(allowed_values=allowed_values)
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: AnyOfValidator[int | str] = validator  # correct
+    var2: AnyOfValidator[str] = validator        # error (7)
+    var3: Validator[int | str] = validator       # correct
+    var4: Validator[str] = validator             # error (9)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.any_of_validator.AnyOfValidator[builtins.int | builtins.str]"
+    main:5: note: Revealed type is "builtins.int | builtins.str"
+    main:7: error: Incompatible types in assignment (expression has type "AnyOfValidator[int | str]", variable has type "AnyOfValidator[str]")  [assignment]
+    main:9: error: Incompatible types in assignment (expression has type "AnyOfValidator[int | str]", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_any_of_validator.yml
+++ b/tests/mypy/validators/test_any_of_validator.yml
@@ -8,7 +8,7 @@
 # also a validator that only returns int/str/anything else.)
 - case: any_of_validator_with_empty_allowed_values
   main: |
-    from typing import Never
+    from typing_extensions import Never
     from validataclass.validators import AnyOfValidator, Validator
     reveal_type(AnyOfValidator(allowed_values=[]))
     reveal_type(AnyOfValidator(allowed_values=[]).validate(42))

--- a/tests/mypy/validators/test_anything_validator.yml
+++ b/tests/mypy/validators/test_anything_validator.yml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check inferred type parameter for AnythingValidator without specifying allowed types (i.e. Any).
+- case: anything_validator_without_parameters
+  main: |
+    from typing import Any
+    from validataclass.validators import AnythingValidator, Validator
+    validator = AnythingValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    # Setting allow_none=True/False should not affect the type (there is no "Any except None" type)
+    reveal_type(AnythingValidator(allow_none=False))
+    var1: AnythingValidator[object] = validator  # correct
+    var2: AnythingValidator[Any] = validator     # correct
+    var3: AnythingValidator[int] = validator     # error (10)
+    var4: Validator[object] = validator          # correct
+    var5: Validator[Any] = validator             # correct
+    var6: Validator[int] = validator             # error (13)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.anything_validator.AnythingValidator[builtins.object]"
+    main:5: note: Revealed type is "builtins.object"
+    main:7: note: Revealed type is "validataclass.validators.anything_validator.AnythingValidator[builtins.object]"
+    main:10: error: Incompatible types in assignment (expression has type "AnythingValidator[object]", variable has type "AnythingValidator[int]")  [assignment]
+    main:13: error: Incompatible types in assignment (expression has type "AnythingValidator[object]", variable has type "Validator[int]")  [assignment]
+
+# Check inferred type parameter for AnythingValidator with only one allowed type.
+- case: anything_validator_with_one_allowed_type
+  main: |
+    from typing import Any
+    from validataclass.validators import AnythingValidator, Validator
+    validator = AnythingValidator(allowed_types=[str])
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    # Setting allowed_types to a type without a list should result in the same type (will be deprecated later though)
+    reveal_type(AnythingValidator(allowed_types=str))
+    var1: AnythingValidator[str] = validator  # correct
+    var2: AnythingValidator[int] = validator  # error (9)
+    var3: Validator[str] = validator          # correct
+    var4: Validator[int] = validator          # error (11)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.anything_validator.AnythingValidator[builtins.str]"
+    main:5: note: Revealed type is "builtins.str"
+    main:7: note: Revealed type is "validataclass.validators.anything_validator.AnythingValidator[builtins.str]"
+    main:9: error: Incompatible types in assignment (expression has type "AnythingValidator[str]", variable has type "AnythingValidator[int]")  [assignment]
+    main:11: error: Incompatible types in assignment (expression has type "AnythingValidator[str]", variable has type "Validator[int]")  [assignment]
+
+# Check inferred type parameter for AnythingValidator with multiple allowed types (including None).
+- case: anything_validator_with_multiple_allowed_types
+  main: |
+    from typing import Any
+    from validataclass.validators import AnythingValidator, Validator
+    # The following will just infer "object" rather than a more precise type union
+    reveal_type(AnythingValidator(allowed_types=(str, int, None)))
+    validator: AnythingValidator[str | int | None] = AnythingValidator(allowed_types=(str, int, None))
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: AnythingValidator[str | int | None] = validator  # correct
+    var2: AnythingValidator[str | int] = validator         # error (9)
+    var3: Validator[str | int | None] = validator          # correct
+    var4: Validator[str | int] = validator                 # error (11)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.anything_validator.AnythingValidator[builtins.object]"
+    main:6: note: Revealed type is "validataclass.validators.anything_validator.AnythingValidator[builtins.str | builtins.int | None]"
+    main:7: note: Revealed type is "builtins.str | builtins.int | None"
+    main:9: error: Incompatible types in assignment (expression has type "AnythingValidator[str | int | None]", variable has type "AnythingValidator[str | int]")  [assignment]
+    main:11: error: Incompatible types in assignment (expression has type "AnythingValidator[str | int | None]", variable has type "Validator[str | int]")  [assignment]

--- a/tests/mypy/validators/test_anything_validator.yml
+++ b/tests/mypy/validators/test_anything_validator.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
 
-# Check inferred type parameter for AnythingValidator without specifying allowed types (i.e. Any).
+# Check inferred type parameter for AnythingValidator without specifying allowed types (i.e. any types are allowed).
 - case: anything_validator_without_parameters
   main: |
     from typing import Any

--- a/tests/mypy/validators/test_big_integer_validator.yml
+++ b/tests/mypy/validators/test_big_integer_validator.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: big_integer_validator_type_params
+  main: |
+    from validataclass.validators import BigIntegerValidator, IntegerValidator, Validator
+    validator = BigIntegerValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[int] = validator    # correct
+    var2: Validator[str] = validator    # error
+    var3: IntegerValidator = validator  # correct
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.big_integer_validator.BigIntegerValidator"
+    main:4: note: Revealed type is "builtins.int"
+    main:6: error: Incompatible types in assignment (expression has type "BigIntegerValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_boolean_validator.yml
+++ b/tests/mypy/validators/test_boolean_validator.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: boolean_validator_type_params
+  main: |
+    from validataclass.validators import BooleanValidator, Validator
+    validator = BooleanValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[bool] = validator  # correct
+    var2: Validator[str] = validator   # error
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.boolean_validator.BooleanValidator"
+    main:4: note: Revealed type is "builtins.bool"
+    main:6: error: Incompatible types in assignment (expression has type "BooleanValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_dataclass_validator.yml
+++ b/tests/mypy/validators/test_dataclass_validator.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: dataclass_validator_type_params
+  main: |
+    from dataclasses import dataclass
+    from validataclass.validators import DataclassValidator, Validator
+
+    @dataclass
+    class TestDataclass:
+        pass
+
+    validator = DataclassValidator(TestDataclass)
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[TestDataclass] = validator  # correct
+    var2: Validator[str] = validator            # error (12)
+  out: |
+    main:9: note: Revealed type is "validataclass.validators.dataclass_validator.DataclassValidator[main.TestDataclass]"
+    main:10: note: Revealed type is "main.TestDataclass"
+    main:12: error: Incompatible types in assignment (expression has type "DataclassValidator[TestDataclass]", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_date_validator.yml
+++ b/tests/mypy/validators/test_date_validator.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: date_validator_type_params
+  main: |
+    from datetime import date
+    from validataclass.validators import DateValidator, Validator
+    validator = DateValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[date] = validator  # correct
+    var2: Validator[str] = validator   # error
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.date_validator.DateValidator"
+    main:5: note: Revealed type is "datetime.date"
+    main:7: error: Incompatible types in assignment (expression has type "DateValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_datetime_validator.yml
+++ b/tests/mypy/validators/test_datetime_validator.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: datetime_validator_type_params
+  main: |
+    from datetime import datetime
+    from validataclass.validators import DateTimeValidator, Validator
+    validator = DateTimeValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[datetime] = validator  # correct
+    var2: Validator[str] = validator       # error
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.datetime_validator.DateTimeValidator"
+    main:5: note: Revealed type is "datetime.datetime"
+    main:7: error: Incompatible types in assignment (expression has type "DateTimeValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_decimal_validator.yml
+++ b/tests/mypy/validators/test_decimal_validator.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: decimal_validator_type_params
+  main: |
+    from decimal import Decimal
+    from validataclass.validators import DecimalValidator, Validator
+    validator = DecimalValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[Decimal] = validator  # correct
+    var2: Validator[str] = validator      # error
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.decimal_validator.DecimalValidator"
+    main:5: note: Revealed type is "decimal.Decimal"
+    main:7: error: Incompatible types in assignment (expression has type "DecimalValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_dict_validator.yml
+++ b/tests/mypy/validators/test_dict_validator.yml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check inferred type parameters for DictValidator with field validators (no default validator).
+#
+# NOTE: The type of field_validators needs to be specified explicitly, but the type of DictValidator can be inferred.
+- case: dict_validator_type_params_with_field_validators
+  main: |
+    from typing import Any
+    from validataclass.validators import DictValidator, IntegerValidator, ListValidator, StringValidator, Validator
+    field_validators: dict[str, Validator[int | list[str]]] = {
+        'foo': IntegerValidator(),
+        'bar': ListValidator(StringValidator()),
+    }
+    validator = DictValidator(field_validators=field_validators)
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: DictValidator[int | list[str]] = validator         # correct
+    var2: DictValidator[Any] = validator                     # correct
+    var3: DictValidator[int] = validator                     # error (12)
+    var4: Validator[dict[str, int | list[str]]] = validator  # correct
+    var5: Validator[dict[str, Any]] = validator              # correct
+    var6: Validator[dict[str, int]] = validator              # error (15)
+    var7: Validator[str] = validator                         # error (16)
+    validator_bad: DictValidator[int | list[str]] = DictValidator(field_validators={
+        'foo': IntegerValidator(),
+        'bar': StringValidator(),  # error (19)
+    })
+  out: |
+    main:8: note: Revealed type is "validataclass.validators.dict_validator.DictValidator[builtins.int | builtins.list[builtins.str]]"
+    main:9: note: Revealed type is "builtins.dict[builtins.str, builtins.int | builtins.list[builtins.str]]"
+    main:12: error: Incompatible types in assignment (expression has type "DictValidator[int | list[str]]", variable has type "DictValidator[int]")  [assignment]
+    main:15: error: Incompatible types in assignment (expression has type "DictValidator[int | list[str]]", variable has type "Validator[dict[str, int]]")  [assignment]
+    main:16: error: Incompatible types in assignment (expression has type "DictValidator[int | list[str]]", variable has type "Validator[str]")  [assignment]
+    main:19: error: Dict entry 1 has incompatible type "str": "StringValidator"; expected "str": "Validator[int | list[str]]"  [dict-item]
+
+# Check inferred type parameters for DictValidator with default validator (no field validators).
+- case: dict_validator_type_params_with_default_validator
+  main: |
+    from typing import Any
+    from validataclass.validators import DictValidator, IntegerValidator, ListValidator, Validator
+    validator = DictValidator(default_validator=ListValidator(IntegerValidator()))
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: DictValidator[list[int]] = validator         # correct
+    var2: DictValidator[Any] = validator               # correct
+    var3: DictValidator[int] = validator               # error (8)
+    var4: Validator[dict[str, list[int]]] = validator  # correct
+    var5: Validator[dict[str, Any]] = validator        # correct
+    var6: Validator[dict[str, int]] = validator        # error (11)
+    var7: Validator[str] = validator                   # error (12)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.dict_validator.DictValidator[builtins.list[builtins.int]]"
+    main:5: note: Revealed type is "builtins.dict[builtins.str, builtins.list[builtins.int]]"
+    main:8: error: Incompatible types in assignment (expression has type "DictValidator[list[int]]", variable has type "DictValidator[int]")  [assignment]
+    main:11: error: Incompatible types in assignment (expression has type "DictValidator[list[int]]", variable has type "Validator[dict[str, int]]")  [assignment]
+    main:12: error: Incompatible types in assignment (expression has type "DictValidator[list[int]]", variable has type "Validator[str]")  [assignment]
+
+# Check inferred type parameters for DictValidator with field validators AND default validator.
+#
+# NOTE: The type of DictValidator cannot be inferred and needs to be specified explicitly.
+- case: dict_validator_type_params_with_field_validators_and_default_validator
+  main: |
+    from typing import Any
+    from validataclass.validators import DictValidator, IntegerValidator, ListValidator, StringValidator, Validator
+    validator: DictValidator[int | str | list[str]] = DictValidator(
+        field_validators={
+            'foo': IntegerValidator(),
+            'bar': ListValidator(StringValidator()),
+        },
+        default_validator=StringValidator(),
+    )
+    reveal_type(validator.validate(42))
+    var1: DictValidator[Any] = validator                           # correct
+    var2: DictValidator[int | list[str]] = validator               # error (12)
+    var3: DictValidator[str] = validator                           # error (13)
+    var4: Validator[dict[str, int | str | list[str]]] = validator  # correct
+    var5: Validator[dict[str, Any]] = validator                    # correct
+    var6: Validator[dict[str, int]] = validator                    # error (16)
+    var7: Validator[str] = validator                               # error (17)
+    validator_bad: DictValidator[int] = DictValidator(
+        field_validators={
+            'foo': IntegerValidator(),
+            'bar': StringValidator(),  # error (21)
+        },
+        default_validator=StringValidator(),  # error (23)
+    )
+  out: |
+    main:10: note: Revealed type is "builtins.dict[builtins.str, builtins.int | builtins.str | builtins.list[builtins.str]]"
+    main:12: error: Incompatible types in assignment (expression has type "DictValidator[int | str | list[str]]", variable has type "DictValidator[int | list[str]]")  [assignment]
+    main:13: error: Incompatible types in assignment (expression has type "DictValidator[int | str | list[str]]", variable has type "DictValidator[str]")  [assignment]
+    main:16: error: Incompatible types in assignment (expression has type "DictValidator[int | str | list[str]]", variable has type "Validator[dict[str, int]]")  [assignment]
+    main:17: error: Incompatible types in assignment (expression has type "DictValidator[int | str | list[str]]", variable has type "Validator[str]")  [assignment]
+    main:21: error: Dict entry 1 has incompatible type "str": "StringValidator"; expected "str": "Validator[int]"  [dict-item]
+    main:23: error: Argument "default_validator" to "DictValidator" has incompatible type "StringValidator"; expected "Validator[int] | None"  [arg-type]

--- a/tests/mypy/validators/test_discard_validator.yml
+++ b/tests/mypy/validators/test_discard_validator.yml
@@ -3,7 +3,7 @@
 # Check inferred type parameter for DiscardValidator without explicit output value (meaning output value is None).
 - case: discard_validator_without_explicit_output_value
   main: |
-    from typing import Never
+    from typing_extensions import Never
     from validataclass.validators import DiscardValidator, Validator
     validator = DiscardValidator()
     reveal_type(validator)
@@ -25,7 +25,7 @@
 # Check inferred type parameter for DiscardValidator with specified output value.
 - case: discard_validator_without_explicit_output_value
   main: |
-    from typing import Never
+    from typing_extensions import Never
     from validataclass.validators import DiscardValidator, Validator
     validator = DiscardValidator(output_value=42)
     reveal_type(validator)

--- a/tests/mypy/validators/test_discard_validator.yml
+++ b/tests/mypy/validators/test_discard_validator.yml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check inferred type parameter for DiscardValidator without explicit output value (meaning output value is None).
+- case: discard_validator_without_explicit_output_value
+  main: |
+    from typing import Never
+    from validataclass.validators import DiscardValidator, Validator
+    validator = DiscardValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: DiscardValidator[None] = validator   # correct
+    var2: DiscardValidator[int] = validator    # error (7)
+    var3: DiscardValidator[Never] = validator  # error (8)
+    var4: Validator[None] = validator          # correct
+    var5: Validator[int] = validator           # error (10)
+    var6: Validator[Never] = validator         # error (11)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.discard_validator.DiscardValidator[None]"
+    main:5: note: Revealed type is "None"
+    main:7: error: Incompatible types in assignment (expression has type "DiscardValidator[None]", variable has type "DiscardValidator[int]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "DiscardValidator[None]", variable has type "DiscardValidator[Never]")  [assignment]
+    main:10: error: Incompatible types in assignment (expression has type "DiscardValidator[None]", variable has type "Validator[int]")  [assignment]
+    main:11: error: Incompatible types in assignment (expression has type "DiscardValidator[None]", variable has type "Validator[Never]")  [assignment]
+
+# Check inferred type parameter for DiscardValidator with specified output value.
+- case: discard_validator_without_explicit_output_value
+  main: |
+    from typing import Never
+    from validataclass.validators import DiscardValidator, Validator
+    validator = DiscardValidator(output_value=42)
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: DiscardValidator[int] = validator    # correct
+    var2: DiscardValidator[None] = validator   # error (7)
+    var3: DiscardValidator[Never] = validator  # error (8)
+    var4: Validator[int] = validator           # correct
+    var5: Validator[None] = validator          # error (10)
+    var6: Validator[Never] = validator         # error (11)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.discard_validator.DiscardValidator[builtins.int]"
+    main:5: note: Revealed type is "builtins.int"
+    main:7: error: Incompatible types in assignment (expression has type "DiscardValidator[int]", variable has type "DiscardValidator[None]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "DiscardValidator[int]", variable has type "DiscardValidator[Never]")  [assignment]
+    main:10: error: Incompatible types in assignment (expression has type "DiscardValidator[int]", variable has type "Validator[None]")  [assignment]
+    main:11: error: Incompatible types in assignment (expression has type "DiscardValidator[int]", variable has type "Validator[Never]")  [assignment]

--- a/tests/mypy/validators/test_email_validator.yml
+++ b/tests/mypy/validators/test_email_validator.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: email_validator_type_params
+  main: |
+    from validataclass.validators import EmailValidator, StringValidator, Validator
+    validator = EmailValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[str] = validator   # correct
+    var2: Validator[int] = validator   # error
+    var3: StringValidator = validator  # correct
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.email_validator.EmailValidator"
+    main:4: note: Revealed type is "builtins.str"
+    main:6: error: Incompatible types in assignment (expression has type "EmailValidator", variable has type "Validator[int]")  [assignment]

--- a/tests/mypy/validators/test_enum_validator.yml
+++ b/tests/mypy/validators/test_enum_validator.yml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: enum_validator_type_params
+  main: |
+    from enum import Enum
+    from validataclass.validators import EnumValidator, Validator
+
+    class TestEnum(Enum):
+        FOO = 1
+        BAR = 2
+
+    class BadEnum(Enum):
+        FOO = 3
+
+    validator = EnumValidator(TestEnum)
+    reveal_type(validator)                     # (12)
+    reveal_type(validator.validate(42))        # (13)
+    var1: EnumValidator[TestEnum] = validator  # correct
+    var2: EnumValidator[BadEnum] = validator   # error (15)
+    var3: EnumValidator[int] = validator       # error (16)
+    var4: Validator[TestEnum] = validator      # correct
+    var5: Validator[int] = validator           # error (18)
+  out: |
+    main:12: note: Revealed type is "validataclass.validators.enum_validator.EnumValidator[main.TestEnum]"
+    main:13: note: Revealed type is "main.TestEnum"
+    main:15: error: Incompatible types in assignment (expression has type "EnumValidator[TestEnum]", variable has type "EnumValidator[BadEnum]")  [assignment]
+    main:16: error: Type argument "int" of "EnumValidator" must be a subtype of "Enum"  [type-var]
+    main:16: error: Incompatible types in assignment (expression has type "EnumValidator[TestEnum]", variable has type "EnumValidator[int]")  [assignment]
+    main:18: error: Incompatible types in assignment (expression has type "EnumValidator[TestEnum]", variable has type "Validator[int]")  [assignment]

--- a/tests/mypy/validators/test_float_to_decimal_validator.yml
+++ b/tests/mypy/validators/test_float_to_decimal_validator.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: float_to_decimal_validator_type_params
+  main: |
+    from decimal import Decimal
+    from validataclass.validators import DecimalValidator, FloatToDecimalValidator, Validator
+    validator = FloatToDecimalValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[Decimal] = validator  # correct
+    var2: Validator[str] = validator      # error
+    var3: DecimalValidator = validator    # correct
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.float_to_decimal_validator.FloatToDecimalValidator"
+    main:5: note: Revealed type is "decimal.Decimal"
+    main:7: error: Incompatible types in assignment (expression has type "FloatToDecimalValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_float_validator.yml
+++ b/tests/mypy/validators/test_float_validator.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: float_validator_type_params
+  main: |
+    from validataclass.validators import FloatValidator, Validator
+    validator = FloatValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[float] = validator  # correct
+    var2: Validator[str] = validator    # error
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.float_validator.FloatValidator"
+    main:4: note: Revealed type is "builtins.float"
+    main:6: error: Incompatible types in assignment (expression has type "FloatValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_integer_validator.yml
+++ b/tests/mypy/validators/test_integer_validator.yml
@@ -1,25 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
 
-- case: integer_validator_typing
+# Check that validator has correct type parameter for Validator[T]
+- case: integer_validator_type_params
   main: |
-    from validataclass.validators import IntegerValidator
-    reveal_type(IntegerValidator())
-    reveal_type(IntegerValidator().validate(42))
+    from validataclass.validators import IntegerValidator, Validator
+    validator = IntegerValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[int] = validator  # correct
+    var2: Validator[str] = validator  # error
   out: |
-    main:2: note: Revealed type is "validataclass.validators.integer_validator.IntegerValidator"
-    main:3: note: Revealed type is "builtins.int"
-
-- case: integer_validator_typing2
-  main: |
-    from validataclass.validators import IntegerValidator
-    reveal_type(IntegerValidator())               # N: Revealed type is "validataclass.validators.integer_validator.IntegerValidator"
-    reveal_type(IntegerValidator().validate(42))  # N: Revealed type is "builtins.int"
-
-# - case: integer_validator_typing_failing
-#   main: |
-#     from validataclass.validators import IntegerValidator
-#     reveal_type(IntegerValidator())
-#     reveal_type(IntegerValidator().validate(42))
-#   out: |
-#     main:2: note: Revealed type is "foo"
-#     main:3: note: Revealed type is "bar"
+    main:3: note: Revealed type is "validataclass.validators.integer_validator.IntegerValidator"
+    main:4: note: Revealed type is "builtins.int"
+    main:6: error: Incompatible types in assignment (expression has type "IntegerValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_integer_validator.yml
+++ b/tests/mypy/validators/test_integer_validator.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+- case: integer_validator_typing
+  main: |
+    from validataclass.validators import IntegerValidator
+    reveal_type(IntegerValidator())
+    reveal_type(IntegerValidator().validate(42))
+  out: |
+    main:2: note: Revealed type is "validataclass.validators.integer_validator.IntegerValidator"
+    main:3: note: Revealed type is "builtins.int"
+
+- case: integer_validator_typing2
+  main: |
+    from validataclass.validators import IntegerValidator
+    reveal_type(IntegerValidator())               # N: Revealed type is "validataclass.validators.integer_validator.IntegerValidator"
+    reveal_type(IntegerValidator().validate(42))  # N: Revealed type is "builtins.int"
+
+# - case: integer_validator_typing_failing
+#   main: |
+#     from validataclass.validators import IntegerValidator
+#     reveal_type(IntegerValidator())
+#     reveal_type(IntegerValidator().validate(42))
+#   out: |
+#     main:2: note: Revealed type is "foo"
+#     main:3: note: Revealed type is "bar"

--- a/tests/mypy/validators/test_list_validator.yml
+++ b/tests/mypy/validators/test_list_validator.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameters for Validator[T] and ListValidator[T]
+- case: list_validator_type_params
+  main: |
+    from validataclass.validators import IntegerValidator, ListValidator, Validator
+    validator = ListValidator(IntegerValidator())
+    reveal_type(validator)
+    reveal_type(validator.validate('foo'))
+    var1: ListValidator[int] = validator    # correct
+    var2: ListValidator[str] = validator    # error (6)
+    var3: Validator[list[int]] = validator  # correct
+    var4: Validator[list[str]] = validator  # error (8)
+    var5: Validator[int] = validator        # error (9)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.list_validator.ListValidator[builtins.int]"
+    main:4: note: Revealed type is "builtins.list[builtins.int]"
+    main:6: error: Incompatible types in assignment (expression has type "ListValidator[int]", variable has type "ListValidator[str]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "ListValidator[int]", variable has type "Validator[list[str]]")  [assignment]
+    main:9: error: Incompatible types in assignment (expression has type "ListValidator[int]", variable has type "Validator[int]")  [assignment]

--- a/tests/mypy/validators/test_none_to_unset_value.yml
+++ b/tests/mypy/validators/test_none_to_unset_value.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
 
 # Check inferred type parameters for NoneToUnsetValue.
-- case: none_to_unset_value_with_default_none
+- case: none_to_unset_value_type_params
   main: |
     from validataclass.helpers import UnsetValueType
     from validataclass.validators import IntegerValidator, NoneToUnsetValue, Noneable, Validator

--- a/tests/mypy/validators/test_none_to_unset_value.yml
+++ b/tests/mypy/validators/test_none_to_unset_value.yml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check inferred type parameters for NoneToUnsetValue.
+- case: none_to_unset_value_with_default_none
+  main: |
+    from validataclass.helpers import UnsetValueType
+    from validataclass.validators import IntegerValidator, NoneToUnsetValue, Noneable, Validator
+    validator = NoneToUnsetValue(IntegerValidator())
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: NoneToUnsetValue[int] = validator            # correct
+    var2: Noneable[int, UnsetValueType] = validator    # correct
+    var3: Noneable[int, None] = validator              # error (8)
+    var4: Validator[int | UnsetValueType] = validator  # correct
+    var5: Validator[int | None] = validator            # error (10)
+    var6: Validator[int] = validator                   # error (11)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.none_to_unset_value.NoneToUnsetValue[builtins.int]"
+    main:5: note: Revealed type is "builtins.int | validataclass.helpers.unset_value.UnsetValueType"
+    main:8: error: Incompatible types in assignment (expression has type "NoneToUnsetValue[int]", variable has type "Noneable[int, None]")  [assignment]
+    main:10: error: Incompatible types in assignment (expression has type "NoneToUnsetValue[int]", variable has type "Validator[int | None]")  [assignment]
+    main:11: error: Incompatible types in assignment (expression has type "NoneToUnsetValue[int]", variable has type "Validator[int]")  [assignment]

--- a/tests/mypy/validators/test_noneable.yml
+++ b/tests/mypy/validators/test_noneable.yml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check inferred type parameters for Noneable (with implicit and explicit default=None).
+- case: noneable_with_default_none
+  main: |
+    from validataclass.validators import IntegerValidator, Noneable, Validator
+    validator = Noneable(IntegerValidator())
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    # Explicit default=None should result in the same type
+    reveal_type(Noneable(IntegerValidator(), default=None))
+    var1: Noneable[int, None] = validator    # correct
+    var2: Noneable[int, int] = validator     # error (8)
+    var3: Validator[int | None] = validator  # correct
+    var4: Validator[int] = validator         # error (10)
+    var5: Validator[None] = validator        # error (11)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.noneable.Noneable[builtins.int, None]"
+    main:4: note: Revealed type is "builtins.int | None"
+    main:6: note: Revealed type is "validataclass.validators.noneable.Noneable[builtins.int, None]"
+    main:8: error: Incompatible types in assignment (expression has type "Noneable[int, None]", variable has type "Noneable[int, int]")  [assignment]
+    main:10: error: Incompatible types in assignment (expression has type "Noneable[int, None]", variable has type "Validator[int]")  [assignment]
+    main:11: error: Incompatible types in assignment (expression has type "Noneable[int, None]", variable has type "Validator[None]")  [assignment]
+
+# Check inferred type parameters for Noneable with a default value of the same type as the validator (e.g. Noneable
+# wrapping an IntegerValidator and converting None to 0).
+- case: noneable_with_default_of_same_type_as_validated
+  main: |
+    from validataclass.validators import IntegerValidator, Noneable, Validator
+    validator = Noneable(IntegerValidator(), default=0)
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Noneable[int, int] = validator   # correct
+    var2: Noneable[int, None] = validator  # error (6)
+    var3: Validator[int] = validator       # correct
+    var4: Validator[str] = validator       # error (8)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.noneable.Noneable[builtins.int, builtins.int]"
+    main:4: note: Revealed type is "builtins.int"
+    main:6: error: Incompatible types in assignment (expression has type "Noneable[int, int]", variable has type "Noneable[int, None]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "Noneable[int, int]", variable has type "Validator[str]")  [assignment]
+
+# Check inferred type parameters for Noneable with a default value of a different type than the validator (e.g. Noneable
+# wrapping an IntegerValidator and converting None to an empty string).
+- case: noneable_with_default_of_different_type_as_validated
+  main: |
+    from validataclass.validators import IntegerValidator, Noneable, Validator
+    validator = Noneable(IntegerValidator(), default='missing value')
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Noneable[int, str] = validator     # correct
+    var2: Noneable[str, int] = validator     # error (6)
+    var3: Validator[int | str] = validator   # correct
+    var4: Validator[int | None] = validator  # error (8)
+    var5: Validator[int] = validator         # error (9)
+    var6: Validator[str] = validator         # error (10)
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.noneable.Noneable[builtins.int, builtins.str]"
+    main:4: note: Revealed type is "builtins.int | builtins.str"
+    main:6: error: Incompatible types in assignment (expression has type "Noneable[int, str]", variable has type "Noneable[str, int]")  [assignment]
+    main:8: error: Incompatible types in assignment (expression has type "Noneable[int, str]", variable has type "Validator[int | None]")  [assignment]
+    main:9: error: Incompatible types in assignment (expression has type "Noneable[int, str]", variable has type "Validator[int]")  [assignment]
+    main:10: error: Incompatible types in assignment (expression has type "Noneable[int, str]", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_numeric_validator.yml
+++ b/tests/mypy/validators/test_numeric_validator.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: numeric_validator_type_params
+  main: |
+    from decimal import Decimal
+    from validataclass.validators import DecimalValidator, NumericValidator, Validator
+    validator = NumericValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[Decimal] = validator  # correct
+    var2: Validator[str] = validator      # error
+    var3: DecimalValidator = validator    # correct
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.numeric_validator.NumericValidator"
+    main:5: note: Revealed type is "decimal.Decimal"
+    main:7: error: Incompatible types in assignment (expression has type "NumericValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_regex_validator.yml
+++ b/tests/mypy/validators/test_regex_validator.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: regex_validator_type_params
+  main: |
+    from validataclass.validators import RegexValidator, StringValidator, Validator
+    validator = RegexValidator(r'([bn]a)*')
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[str] = validator   # correct
+    var2: Validator[int] = validator   # error
+    var3: StringValidator = validator  # correct
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.regex_validator.RegexValidator"
+    main:4: note: Revealed type is "builtins.str"
+    main:6: error: Incompatible types in assignment (expression has type "RegexValidator", variable has type "Validator[int]")  [assignment]

--- a/tests/mypy/validators/test_reject_validator.yml
+++ b/tests/mypy/validators/test_reject_validator.yml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that inferred type parameter for RejectValidator is Never.
+#
+# NOTE: There are no error cases here, i.e. no incompatible type parameters for Validator, because Never is the bottom
+# type and therefore a subset of every other (union of) type(s): int == int | Never, so Never is a subset of int, which
+# also means that a `Validator[Never]` is a valid `Validator[int]`. (In other words: a validator that never returns is
+# also a validator that only returns int/str/anything else.)
+- case: reject_validator_rejects_anything
+  main: |
+    from typing import Never
+    from validataclass.validators import RejectValidator, Validator
+    validator = RejectValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[Never] = validator  # correct
+    var2: Validator[None] = validator   # actually also correct
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.reject_validator.RejectValidator"
+    main:5: note: Revealed type is "Never"
+
+# Check that inferred type parameter for a Noneable(RejectValidator) is None and not Never.
+- case: reject_validator_wrapped_in_noneable
+  main: |
+    from typing import Never
+    from validataclass.validators import Noneable, RejectValidator, Validator
+    validator = Noneable(RejectValidator())
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Noneable[Never, None] = validator  # correct
+    var2: Validator[None] = validator        # correct
+    var3: Validator[Never] = validator       # error (8)
+    var4: Validator[int] = validator         # error (9)
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.noneable.Noneable[Never, None]"
+    main:5: note: Revealed type is "None"
+    main:8: error: Incompatible types in assignment (expression has type "Noneable[Never, None]", variable has type "Validator[Never]")  [assignment]
+    main:9: error: Incompatible types in assignment (expression has type "Noneable[Never, None]", variable has type "Validator[int]")  [assignment]

--- a/tests/mypy/validators/test_reject_validator.yml
+++ b/tests/mypy/validators/test_reject_validator.yml
@@ -8,7 +8,7 @@
 # also a validator that only returns int/str/anything else.)
 - case: reject_validator_rejects_anything
   main: |
-    from typing import Never
+    from typing_extensions import Never
     from validataclass.validators import RejectValidator, Validator
     validator = RejectValidator()
     reveal_type(validator)
@@ -22,7 +22,7 @@
 # Check that inferred type parameter for a Noneable(RejectValidator) is None and not Never.
 - case: reject_validator_wrapped_in_noneable
   main: |
-    from typing import Never
+    from typing_extensions import Never
     from validataclass.validators import Noneable, RejectValidator, Validator
     validator = Noneable(RejectValidator())
     reveal_type(validator)

--- a/tests/mypy/validators/test_string_validator.yml
+++ b/tests/mypy/validators/test_string_validator.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: string_validator_type_params
+  main: |
+    from validataclass.validators import StringValidator, Validator
+    validator = StringValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[str] = validator  # correct
+    var2: Validator[int] = validator  # error
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.string_validator.StringValidator"
+    main:4: note: Revealed type is "builtins.str"
+    main:6: error: Incompatible types in assignment (expression has type "StringValidator", variable has type "Validator[int]")  [assignment]

--- a/tests/mypy/validators/test_time_validator.yml
+++ b/tests/mypy/validators/test_time_validator.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: time_validator_type_params
+  main: |
+    from datetime import time
+    from validataclass.validators import TimeValidator, Validator
+    validator = TimeValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[time] = validator  # correct
+    var2: Validator[str] = validator   # error
+  out: |
+    main:4: note: Revealed type is "validataclass.validators.time_validator.TimeValidator"
+    main:5: note: Revealed type is "datetime.time"
+    main:7: error: Incompatible types in assignment (expression has type "TimeValidator", variable has type "Validator[str]")  [assignment]

--- a/tests/mypy/validators/test_url_validator.yml
+++ b/tests/mypy/validators/test_url_validator.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: url_validator_type_params
+  main: |
+    from validataclass.validators import StringValidator, UrlValidator, Validator
+    validator = UrlValidator()
+    reveal_type(validator)
+    reveal_type(validator.validate(42))
+    var1: Validator[str] = validator   # correct
+    var2: Validator[int] = validator   # error
+    var3: StringValidator = validator  # correct
+  out: |
+    main:3: note: Revealed type is "validataclass.validators.url_validator.UrlValidator"
+    main:4: note: Revealed type is "builtins.str"
+    main:6: error: Incompatible types in assignment (expression has type "UrlValidator", variable has type "Validator[int]")  [assignment]

--- a/tests/mypy/validators/test_validator.yml
+++ b/tests/mypy/validators/test_validator.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
 
-# Check that mypy complains about subclasses of Validator without type parameter
+# Check that mypy complains about subclasses of Validator without type parameter.
 - case: validator_subclass_requires_type_param
   main: |
     from typing import Any
@@ -10,3 +10,14 @@
             return str(input_data)
   out: |
     main:3: error: Missing type parameters for generic type "Validator"  [type-arg]
+
+# Check that mypy complains when return type of validate method doesn't match Validator type parameter.
+- case: validator_with_incompatible_validate_return_type
+  main: |
+    from typing import Any
+    from validataclass.validators import Validator
+    class TestValidator(Validator[int]):
+        def validate(self, input_data: Any, **kwargs: Any) -> str:
+            return str(input_data)
+  out: |
+    main:4: error: Return type "str" of "validate" incompatible with return type "int" in supertype "validataclass.validators.validator.Validator"  [override]

--- a/tests/mypy/validators/test_validator.yml
+++ b/tests/mypy/validators/test_validator.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that mypy complains about subclasses of Validator without type parameter
+- case: validator_subclass_requires_type_param
+  main: |
+    from typing import Any
+    from validataclass.validators import Validator
+    class TestValidator(Validator):
+        def validate(self, input_data: Any, **kwargs: Any) -> str:
+            return str(input_data)
+  out: |
+    main:3: error: Missing type parameters for generic type "Validator"  [type-arg]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,7 +96,7 @@ def assert_decimal(actual: Decimal, expected: Decimal | str) -> None:
 
 
 # Test validator that parses context arguments
-class UnitTestContextValidator(Validator):
+class UnitTestContextValidator(Validator[str]):
     """
     Context-sensitive string validator, only for unit testing.
 

--- a/tests/unit/dataclasses/_helpers.py
+++ b/tests/unit/dataclasses/_helpers.py
@@ -8,7 +8,6 @@ import dataclasses
 from typing import Any
 
 from validataclass.dataclasses import Default
-from validataclass.validators import T_Dataclass
 
 
 # Test helpers for dataclass tests
@@ -45,7 +44,7 @@ def assert_field_no_default(field: dataclasses.Field[Any]) -> None:
     assert 'validator_default' not in field.metadata
 
 
-def get_dataclass_fields(cls: type[T_Dataclass]) -> dict[str, dataclasses.Field[Any]]:
+def get_dataclass_fields(cls: type[object]) -> dict[str, dataclasses.Field[Any]]:
     """
     Returns a dictionary containing all fields of a given dataclass.
     """

--- a/tests/unit/dataclasses/validataclass_test.py
+++ b/tests/unit/dataclasses/validataclass_test.py
@@ -214,7 +214,8 @@ class ValidatorDataclassTest:
         class UnitTestDataclass:
             field_list: list[int] = ListValidator(IntegerValidator()), Default([])
             field_dict: dict[str, int] = (
-                DictValidator(field_validators={'foo': IntegerValidator()}),
+                # TODO: Proper typing requires mypy plugin
+                DictValidator(field_validators={'foo': IntegerValidator()}),  # type: ignore[arg-type]
                 Default({'foo': 0}),
             )
 

--- a/tests/unit/validators/allow_empty_string_test.py
+++ b/tests/unit/validators/allow_empty_string_test.py
@@ -5,6 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
+from typing import Never
 
 import pytest
 from validataclass.exceptions import ValidationError
@@ -92,7 +93,7 @@ class AllowEmptyStringTest:
         """
         # Use an empty list as an example for a mutable default value. This doesn't make a lot of sense together with
         # an IntegerValidator but simplifies the test.
-        validator = AllowEmptyString(IntegerValidator(), default=[])
+        validator: AllowEmptyString[int, list[Never]] = AllowEmptyString(IntegerValidator(), default=[])
 
         first_list = validator.validate('')
         second_list = validator.validate('')

--- a/tests/unit/validators/allow_empty_string_test.py
+++ b/tests/unit/validators/allow_empty_string_test.py
@@ -5,12 +5,13 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
-from typing import Never
 
 import pytest
+from typing_extensions import Never
+
+from tests.test_utils import UnitTestContextValidator
 from validataclass.exceptions import ValidationError
 from validataclass.validators import AllowEmptyString, DecimalValidator, IntegerValidator
-from tests.test_utils import UnitTestContextValidator
 
 
 class AllowEmptyStringTest:

--- a/tests/unit/validators/any_of_validator_test.py
+++ b/tests/unit/validators/any_of_validator_test.py
@@ -290,7 +290,7 @@ class AnyOfValidatorTest:
     @staticmethod
     def test_empty_allowed_values_with_allowed_types():
         """ Test AnyOfValidator with an empty list of allowed values (requires explicit allowed_types). """
-        validator = AnyOfValidator([], allowed_types=[str])
+        validator: AnyOfValidator[str] = AnyOfValidator([], allowed_types=[str])
 
         # This validator does not allow any input
         with pytest.raises(ValueNotAllowedError) as exception_info:

--- a/tests/unit/validators/dict_validator_test.py
+++ b/tests/unit/validators/dict_validator_test.py
@@ -5,9 +5,9 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
-from typing import Never
 
 import pytest
+from typing_extensions import Never
 
 from tests.test_utils import UnitTestContextValidator
 from validataclass.exceptions import (

--- a/tests/unit/validators/dict_validator_test.py
+++ b/tests/unit/validators/dict_validator_test.py
@@ -5,6 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
+from typing import Never
 
 import pytest
 
@@ -114,7 +115,6 @@ class DictValidatorTest:
         validator = DictValidator(
             default_validator=DecimalValidator(),
             required_fields=['foo', 'bar'],
-
         )
 
         validated_data = validator.validate({
@@ -169,7 +169,7 @@ class DictValidatorTest:
         Test a DictValidator with no field validators, which only returns empty dictionaries. Input dictionaries might
         contain fields, but they will be ignored.
         """
-        validator = DictValidator(field_validators={})
+        validator: DictValidator[Never] = DictValidator(field_validators={})
         assert validator.validate(input_dict) == {}
 
     @staticmethod
@@ -337,7 +337,7 @@ class DictValidatorTest:
     @staticmethod
     def test_dict_with_noneable_fields():
         """ Validate a dictionary that allows fields with None as value. """
-        validator = DictValidator(field_validators={
+        validator: DictValidator[Decimal | None] = DictValidator(field_validators={
             'test_a': Noneable(DecimalValidator()),
             'test_b': Noneable(DecimalValidator()),
         })
@@ -358,7 +358,7 @@ class DictValidatorTest:
     @staticmethod
     def test_with_context_arguments():
         """ Test that DictValidator passes context arguments down to the default and field validators. """
-        validator = DictValidator(
+        validator: DictValidator[str] = DictValidator(
             field_validators={
                 'unittest': UnitTestContextValidator(prefix='FIELD')
             },
@@ -557,7 +557,7 @@ class DictValidatorTest:
         Create a subclassed DictValidator that sets field_validators and required_fields and test it with valid data.
         """
 
-        class UnitTestDictValidator(DictValidator):
+        class UnitTestDictValidator(DictValidator[str | Decimal]):
             field_validators = {
                 'name': StringValidator(),
                 'value': DecimalValidator(),
@@ -602,7 +602,7 @@ class DictValidatorTest:
         Create a subclassed DictValidator that sets field_validators and required_fields and test it with invalid data.
         """
 
-        class UnitTestDictValidator(DictValidator):
+        class UnitTestDictValidator(DictValidator[str | Decimal]):
             field_validators = {
                 'name': StringValidator(),
                 'value': DecimalValidator(),
@@ -624,7 +624,7 @@ class DictValidatorTest:
     def test_subclassed_dict_with_default_validator_valid():
         """ Create a subclassed DictValidator that sets default_validator and test it with valid data. """
 
-        class UnitTestDefaultDictValidator(DictValidator):
+        class UnitTestDefaultDictValidator(DictValidator[Decimal]):
             default_validator = DecimalValidator()
 
         validator = UnitTestDefaultDictValidator()
@@ -645,7 +645,7 @@ class DictValidatorTest:
     def test_subclassed_dict_with_default_validator_invalid():
         """ Create a subclassed DictValidator that sets default_validator and test it with invalid data. """
 
-        class UnitTestDefaultDictValidator(DictValidator):
+        class UnitTestDefaultDictValidator(DictValidator[Decimal]):
             default_validator = DecimalValidator()
 
         validator = UnitTestDefaultDictValidator()

--- a/tests/unit/validators/enum_validator_test.py
+++ b/tests/unit/validators/enum_validator_test.py
@@ -499,7 +499,7 @@ class EnumValidatorTest:
         """
         # This case should never happen in real life, so we need to manipulate the validator parameters post-creation
         validator = EnumValidator(UnitTestStringEnum)
-        validator.allowed_values.append('bananana')
+        validator.any_of_validator.allowed_values.append('bananana')
 
         with pytest.raises(ValueNotAllowedError):
             validator.validate('bananana')

--- a/tests/unit/validators/list_validator_test.py
+++ b/tests/unit/validators/list_validator_test.py
@@ -86,7 +86,7 @@ class ListValidatorTest:
     )
     def test_valid_nested_list(input_list, expected_output):
         """ Test nested ListValidator to validate lists of lists of decimals. """
-        validator: ListValidator[Decimal] = ListValidator(ListValidator(DecimalValidator()))
+        validator: ListValidator[list[Decimal]] = ListValidator(ListValidator(DecimalValidator()))
         output_list = validator.validate(input_list)
 
         for sublist in output_list:

--- a/tests/unit/validators/noneable_test.py
+++ b/tests/unit/validators/noneable_test.py
@@ -5,6 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
+from typing import Never
 
 import pytest
 
@@ -105,7 +106,7 @@ class NoneableTest:
         """
         # Use an empty list as an example for a mutable default value. This doesn't make a lot of sense together with
         # an IntegerValidator but simplifies the test.
-        validator = Noneable(IntegerValidator(), default=[])
+        validator: Noneable[int, list[Never]] = Noneable(IntegerValidator(), default=[])
 
         first_list = validator.validate(None)
         second_list = validator.validate(None)

--- a/tests/unit/validators/noneable_test.py
+++ b/tests/unit/validators/noneable_test.py
@@ -5,9 +5,9 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 from decimal import Decimal
-from typing import Never
 
 import pytest
+from typing_extensions import Never
 
 from tests.test_utils import UnitTestContextValidator
 from validataclass.exceptions import ValidationError

--- a/tests/unit/validators/reject_validator_test.py
+++ b/tests/unit/validators/reject_validator_test.py
@@ -80,7 +80,7 @@ class RejectValidatorTest:
     def test_allow_none():
         """ Test that RejectValidator allows None if allow_none is True. """
         validator = RejectValidator(allow_none=True)
-        assert validator.validate(None) is None  # type: ignore[func-returns-value]
+        assert validator.validate(None) is None
 
     # Tests with custom errors
 

--- a/tests/unit/validators/validator_test.py
+++ b/tests/unit/validators/validator_test.py
@@ -23,7 +23,7 @@ class ValidatorTest:
         """
         # Ensure that Validator creation causes a DeprecationWarning
         with pytest.deprecated_call():
-            class ValidatorWithoutKwargs(Validator):
+            class ValidatorWithoutKwargs(Validator[Any]):
                 def validate(self, input_data: Any) -> Any:  # type: ignore[override]  # noqa
                     return input_data
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,10 @@ per-file-ignores =
 extras = testing
 commands = python -m pytest --cov --cov-append {posargs}
 
+[testenv:pytest-mypy]
+extras = testing
+commands = python -m pytest tests/mypy
+
 [testenv:flake8]
 commands = flake8 src/ tests/
 


### PR DESCRIPTION
**This is part of making validataclass mypy-compatible (#116).**
**Please note that the target branch is `dev-mypy` instead of main.**

---

This PR improves the typing of validator classes a lot by changing the `Validator` base class to a Generic class `Validator[T]`. This came with a lot of necessary follow-up changes, so it's a rather large PR. Most of it are new tests, though.

This is one big step towards full mypy support (see also: #116).

### Generic Validator class

The `Validator` base class is a Generic class now (`Validator[T]`), with a type parameter that specifies the type of the validator's **output** value, i.e. the return type of the `validate()` method.

All classes have been adjusted to properly set this type parameter and add their own type parameters if needed to allow for proper typing. For example, `ListValidator[T]` (which already was a Generic) inherits from `Validator[list[T]]` now, and `Noneable[T_Wrapped, T_Default]` (new type parameters) inherits from `Validator[T_Wrapped | T_Default]`.

### Composition instead of inheritance for extended validators

Several "extended" validators that are based on another validator change the return type had to be modified to use composition rather than inheritance (otherwise changing the return type violates the [LSP](https://en.wikipedia.org/wiki/Liskov_substitution_principle)). For example, the `DecimalValidator` used to be a subclass of `StringValidator` to first validate the input as a string without reinventing the StringValidator, and then try to parse the string as a decimal. However, `Decimal` is not a subclass of `str`, so the return type of `DecimalValidator` wasn't compatible with the return type of its super class. Now, `DecimalValidator` inherits directly from `Validator[Decimal]` and uses a separate `StringValidator` (stored in an attribute) for the string validation. This is a **breaking change**, although one that *should* not matter that much in actual projects unless they meddle with a validator's internals (which are technically public, hence it's a breaking change).

The following validators are affected by this change:

- `DataclassValidator`: Used to inherit from `DictValidator`, now it inherits from `Validator[T_Dataclass]` and uses a separate `DictValidator.` (This is an implementation detail that can change at any point in the future.)
- `DateValidator`, `DateTimeValidator`, `TimeValidator`: Used to inherit from `StringValidator`, now inherit from `Validator[datetime.date]` etc. and use a separate `StringValidator` for basic string validation.
- `DecimalValidator`: Used to inherit from `StringValidator`, now inherits from `Validator[Decimal]`.
- `EnumValidator`: Used to inherit from `AnyOfValidator`, now inherits from `Validator[T_Enum]` and uses a separate `AnyOfValidator`.

It is recommended for users of the library to check and adjust their custom validators accordingly. Validators based on inheritance should still work the same way as before, but if the return type is changed in an incompatible way, the validator should be rewritten to use composition for its base validator.

Please note that extending a validator by inheritance is still perfectly fine as long as the return type is the same as (or a subclass of) the original return type of the super class. For example, the `FloatToDecimalValidator` still inherits from `DecimalValidator` because it still returns a `Decimal`, it just modifies/extends the validation behavior.

### _ensure_type with None

A minor change in the `Validator._ensure_type()` method was also done: This function now accepts `None` if `type(None)` is included in the list of accepted types. This is a small extension of that function and not a breaking change. It allows to simplify some code (and typing) e.g. in the `AnyOfValidator` because it doesn't need to handle `None` as a special case anymore.

### Deprecate importing and reusing TypeVars

Another small change is that the TypeVars used by the built-in validators (`T_Dataclass`, `T_Enum` and `T_ListItem`) have been removed from `__all__`, i.e. the modules don't export these TypeVars anymore. They can still be imported and used, but this is considered **deprecated** now and linters should complain about importing them. Instead of reusing these TypeVars, it's recommended to define your own TypeVars (or use the new [type parameter syntax](https://peps.python.org/pep-0695/) when using Python 3.12 or above).

This is only a deprecation, not a breaking change yet, but the compatibility imports in `validataclass.validators` will be removed in a future version.

### Typing tests with pytest-mypy-plugins

In order to test all of these new changes and provide a consistent typing experience, we've added a second type of automated tests besides unit tests. There are now "typing tests" using the pytest plugin [pytest-mypy-plugins](https://github.com/typeddjango/pytest-mypy-plugins/). These can be found in `tests/mypy/` and are defined using YAML files. They will be automatically run together with the unit tests as part of running pytest (you can use `make test-typing` if you specifically only want to run the typing tests).