### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
 
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,13 @@ _docker-tox:
 
 # Run complete tox test suite in a multi-python Docker container
 .PHONY: docker-tox
-docker-tox: TOX_ARGS='-e clean,py313,py312,py311,py310,report,flake8,py313-mypy'
+docker-tox: TOX_ARGS='-e clean,py310,py311,py312,py313,py314,report,flake8,mypy'
 docker-tox: _docker-tox
 
 # Run partial tox test suites in Docker
-.PHONY: docker-test-py313 docker-test-py312 docker-test-py311 docker-test-py310
+.PHONY: docker-test-py314 docker-test-py313 docker-test-py312 docker-test-py311 docker-test-py310
+docker-test-py314: TOX_ARGS="-e clean,py314,py314-report"
+docker-test-py314: _docker-tox
 docker-test-py313: TOX_ARGS="-e clean,py313,py313-report"
 docker-test-py313: _docker-tox
 docker-test-py312: TOX_ARGS="-e clean,py312,py312-report"
@@ -93,11 +95,14 @@ docker-test-all:
 	make docker-test-py311
 	make docker-test-py312
 	make docker-test-py313
+	make docker-test-py314
 
 # Run mypy using all different (or specific) Python versions in Docker
-.PHONY: docker-mypy-all docker-mypy-py313 docker-mypy-py312 docker-mypy-py311 docker-mypy-py310
-docker-mypy-all: TOX_ARGS="-e py313-mypy,py312-mypy,py311-mypy,py310-mypy"
+.PHONY: docker-mypy-py314 docker-mypy-all docker-mypy-py313 docker-mypy-py312 docker-mypy-py311 docker-mypy-py310
+docker-mypy-all: TOX_ARGS="-e py310-mypy,py311-mypy,py312-mypy,py313-mypy,py314-mypy"
 docker-mypy-all: _docker-tox
+docker-mypy-py314: TOX_ARGS="-e py314-mypy"
+docker-mypy-py314: _docker-tox
 docker-mypy-py313: TOX_ARGS="-e py313-mypy"
 docker-mypy-py313: _docker-tox
 docker-mypy-py312: TOX_ARGS="-e py312-mypy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,16 +31,16 @@ package_dir =
 packages = find:
 python_requires = ~=3.10
 install_requires =
-    typing-extensions ~= 4.14
+    typing-extensions ~= 4.15
 
 [options.packages.find]
 where = src
 
 [options.extras_require]
 testing =
-    pytest ~= 8.4
-    pytest-cov ~= 6.2
+    pytest ~= 9.0
+    pytest-cov ~= 7.0
     pytest-mypy-plugins ~= 3.2
-    coverage ~= 7.9
+    coverage ~= 7.13
     flake8 ~= 7.3
     mypy ~= 1.19

--- a/src/validataclass/dataclasses/validataclass.py
+++ b/src/validataclass/dataclasses/validataclass.py
@@ -7,6 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 import dataclasses
 from collections import namedtuple
 from collections.abc import Callable
+from inspect import get_annotations
 from typing import Any, TypeVar, overload
 
 from typing_extensions import dataclass_transform
@@ -112,7 +113,7 @@ def _prepare_dataclass_metadata(cls: type[_T]) -> None:
     existing_validator_fields = _get_existing_validator_fields(cls)
 
     # Get class annotations
-    cls_annotations = cls.__dict__.get('__annotations__', {})
+    cls_annotations = get_annotations(cls)
 
     # Check for fields/attributes that have validators defined but missing a type annotation (most likely an error)
     for name, value in cls.__dict__.items():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.5.1
-envlist = clean,py{313,312,311,310},report,flake8,mypy
+envlist = clean,py{310,311,312,313,314},report,flake8,mypy
 skip_missing_interpreters = true
 
 [flake8]
@@ -24,13 +24,13 @@ commands = python -m pytest {posargs:tests/mypy}
 [testenv:flake8]
 commands = flake8 src/ tests/
 
-[testenv:mypy,py{313,312,311,310}-mypy]
+[testenv:mypy,py{310,311,312,313,314}-mypy]
 commands = mypy
 
 [testenv:clean]
 commands = coverage erase
 
-[testenv:report,py{313,312,311,310}-report]
+[testenv:report,py{310,311,312,313,314}-report]
 commands =
     coverage html
     coverage report --fail-under=100


### PR DESCRIPTION
**IMPORTANT: This PR is marked as a draft because the branch is based on another branch: [generic-based-defaults](https://github.com/binary-butterfly/validataclass/pull/136).
It should be rebased on dev-mypy and only merged after that branch has been merged.**

This PR adds official support for Python 3.14.

This only required a small change in how the `@validataclass` decorator gets the annotations of a dataclass, due to annotation evaluation now being deferred (see PEP 649).

I've also updated the package dependency and the dev dependencies.