### PR TITLE
Enable more strict mypy rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ strict_equality_for_none = true
 warn_unreachable = true
 enable_error_code = [
     "deprecated",
-    # TODO: Enable this and fix issues?
-    # "explicit-override",
+    "explicit-override",
     "ignore-without-code",
     # TODO: Maybe enable this is in the future (when we have the mypy plugin)
     # "mutable-override",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,22 @@ explicit_package_bases = true
 strict = true
 
 # Enable further checks that are not included in strict mode
+disallow_any_unimported = true
+strict_equality_for_none = true
+warn_unreachable = true
 enable_error_code = [
     "deprecated",
+    # TODO: Enable this and fix issues?
+    # "explicit-override",
+    "ignore-without-code",
+    # TODO: Maybe enable this is in the future (when we have the mypy plugin)
+    # "mutable-override",
+    "possibly-undefined",
+    "redundant-expr",
+    "redundant-self",
+    "truthy-bool",
+    "truthy-iterable",
+    "unused-awaitable",
 ]
 
 [[tool.mypy.overrides]]

--- a/src/validataclass/dataclasses/defaults.py
+++ b/src/validataclass/dataclasses/defaults.py
@@ -212,5 +212,5 @@ class _NoDefault(BaseDefault[Never]):
 
 # Create sentinel object NoDefault, redefine __new__ to always return the same instance, and delete temporary class
 NoDefault = _NoDefault()
-_NoDefault.__new__ = lambda cls: NoDefault  # type: ignore
+_NoDefault.__new__ = lambda cls: NoDefault  # type: ignore[assignment, method-assign, return-value]
 del _NoDefault

--- a/src/validataclass/dataclasses/defaults.py
+++ b/src/validataclass/dataclasses/defaults.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import Any, Generic, TypeVar
 
-from typing_extensions import Never, Self
+from typing_extensions import Never, Self, override
 
 from validataclass.helpers import UnsetValue, UnsetValueType
 
@@ -35,9 +35,11 @@ class BaseDefault(Generic[T_Default], ABC):
     See also: `Default`, `DefaultFactory()`, `DefaultUnset`, `NoDefault`
     """
 
+    @override
     def __repr__(self) -> str:
         return type(self).__name__
 
+    @override
     def __eq__(self, other: Any) -> bool:
         return NotImplemented
 
@@ -79,9 +81,11 @@ class Default(BaseDefault[T_Default]):
         # If copying the value resulted in the identical object, no factory is needed
         self._needs_factory = self._value is not value
 
+    @override
     def __repr__(self) -> str:
         return f'{type(self).__name__}({self._value!r})'
 
+    @override
     def __eq__(self, other: Any) -> bool:
         # Only handle this if self is of the same type as other OR self is a subclass of other.
         # In other words, don't handle this if other is a completely different type or more specialized than self.
@@ -90,6 +94,7 @@ class Default(BaseDefault[T_Default]):
             return isinstance(other, Default) and bool(self._value == other._value)
         return NotImplemented
 
+    @override
     def __hash__(self) -> int:
         return hash(self._value)
 
@@ -105,12 +110,14 @@ class Default(BaseDefault[T_Default]):
             return self
         raise TypeError(f"'{type(self).__name__}' object is not callable")
 
+    @override
     def get_value(self) -> T_Default:
         """
         Get actual default value.
         """
         return deepcopy(self._value)
 
+    @override
     def needs_factory(self) -> bool:
         """
         Return True if a dataclass `default_factory` is needed for this default object, for example if the value is a
@@ -144,9 +151,11 @@ class DefaultFactory(BaseDefault[T_Default]):
     def __init__(self, factory: Callable[[], T_Default]):
         self._factory = factory
 
+    @override
     def __repr__(self) -> str:
         return f'{type(self).__name__}({self._factory!r})'
 
+    @override
     def __eq__(self, other: Any) -> bool:
         # Only handle this if self is of the same type as other OR self is a subclass of other.
         # In other words, don't handle this if other is a completely different type or more specialized than self.
@@ -155,15 +164,18 @@ class DefaultFactory(BaseDefault[T_Default]):
             return isinstance(other, DefaultFactory) and bool(self._factory == other._factory)
         return NotImplemented
 
+    @override
     def __hash__(self) -> int:
         return hash(self._factory)
 
+    @override
     def get_value(self) -> T_Default:
         """
         Get an actual default value by calling the factory function.
         """
         return self._factory()
 
+    @override
     def needs_factory(self) -> bool:
         """
         Return True if a dataclass `default_factory` is needed for this default object.
@@ -185,18 +197,22 @@ class _NoDefault(BaseDefault[Never]):
     A validataclass field with `NoDefault` is equivalent to a validataclass field without specified default.
     """
 
+    @override
     def __repr__(self) -> str:
         return 'NoDefault'
 
+    @override
     def __eq__(self, other: Any) -> bool:
         # Nothing is equal to NoDefault except itself
         return self is other
 
     __hash__ = BaseDefault.__hash__
 
+    @override
     def get_value(self) -> Never:
         raise ValueError('No default value specified!')
 
+    @override
     def needs_factory(self) -> bool:
         raise NotImplementedError('NoDefault can be used neither as a value nor as a factory.')
 

--- a/src/validataclass/exceptions/base_exceptions.py
+++ b/src/validataclass/exceptions/base_exceptions.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
+from typing_extensions import override
+
 __all__ = [
     'ValidationError',
 ]
@@ -38,10 +40,12 @@ class ValidationError(Exception):
             self.reason = reason
         self.extra_data = {key: value for key, value in kwargs.items() if value is not None}
 
+    @override
     def __repr__(self) -> str:
         params_string = ', '.join(f'{key}={value}' for key, value in self._get_repr_dict().items())
         return f'{type(self).__name__}({params_string})'
 
+    @override
     def __str__(self) -> str:
         return self.__repr__()
 

--- a/src/validataclass/exceptions/base_exceptions.py
+++ b/src/validataclass/exceptions/base_exceptions.py
@@ -39,7 +39,7 @@ class ValidationError(Exception):
         self.extra_data = {key: value for key, value in kwargs.items() if value is not None}
 
     def __repr__(self) -> str:
-        params_string = ', '.join(f'{key}={value}' for key, value in self._get_repr_dict().items() if value is not None)
+        params_string = ', '.join(f'{key}={value}' for key, value in self._get_repr_dict().items())
         return f'{type(self).__name__}({params_string})'
 
     def __str__(self) -> str:

--- a/src/validataclass/exceptions/common_exceptions.py
+++ b/src/validataclass/exceptions/common_exceptions.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
+from typing_extensions import override
+
 from .base_exceptions import ValidationError
 
 __all__ = [
@@ -69,6 +71,7 @@ class InvalidTypeError(ValidationError):
         if new_type not in self.expected_types:
             self.expected_types.append(new_type)
 
+    @override
     def to_dict(self) -> dict[str, Any]:
         base_dict = super().to_dict()
         self.expected_types.sort()

--- a/src/validataclass/exceptions/dataclass_exceptions.py
+++ b/src/validataclass/exceptions/dataclass_exceptions.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
+from typing_extensions import override
+
 from .base_exceptions import ValidationError
 
 __all__ = [
@@ -74,6 +76,7 @@ class DataclassPostValidationError(ValidationError):
             assert all(isinstance(error, ValidationError) for error in field_errors.values())
             self.field_errors = field_errors
 
+    @override
     def _get_repr_dict(self) -> dict[str, str]:
         base_dict = super()._get_repr_dict()
 
@@ -84,6 +87,7 @@ class DataclassPostValidationError(ValidationError):
 
         return base_dict
 
+    @override
     def to_dict(self) -> dict[str, Any]:
         base_dict = super().to_dict()
 

--- a/src/validataclass/exceptions/dict_exceptions.py
+++ b/src/validataclass/exceptions/dict_exceptions.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
+from typing_extensions import override
+
 from .base_exceptions import ValidationError
 
 __all__ = [
@@ -33,6 +35,7 @@ class DictFieldsValidationError(ValidationError):
         assert all(isinstance(error, ValidationError) for error in field_errors.values())
         self.field_errors = field_errors
 
+    @override
     def _get_repr_dict(self) -> dict[str, str]:
         base_dict = super()._get_repr_dict()
         return {
@@ -40,6 +43,7 @@ class DictFieldsValidationError(ValidationError):
             'field_errors': repr(self.field_errors),
         }
 
+    @override
     def to_dict(self) -> dict[str, Any]:
         base_dict = super().to_dict()
         return {

--- a/src/validataclass/exceptions/list_exceptions.py
+++ b/src/validataclass/exceptions/list_exceptions.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
+from typing_extensions import override
+
 from .base_exceptions import ValidationError
 
 __all__ = [
@@ -32,6 +34,7 @@ class ListItemsValidationError(ValidationError):
         assert all(isinstance(error, ValidationError) for error in item_errors.values())
         self.item_errors = item_errors
 
+    @override
     def _get_repr_dict(self) -> dict[str, str]:
         base_dict = super()._get_repr_dict()
         return {
@@ -39,6 +42,7 @@ class ListItemsValidationError(ValidationError):
             'item_errors': repr(self.item_errors),
         }
 
+    @override
     def to_dict(self) -> dict[str, Any]:
         base_dict = super().to_dict()
         return {

--- a/src/validataclass/helpers/datetime_range.py
+++ b/src/validataclass/helpers/datetime_range.py
@@ -9,6 +9,8 @@ from collections.abc import Callable
 from datetime import datetime, timedelta, timezone, tzinfo
 from typing import TypeAlias
 
+from typing_extensions import override
+
 __all__ = [
     'BaseDateTimeRange',
     'DateTimeRange',
@@ -101,9 +103,11 @@ class DateTimeRange(BaseDateTimeRange):
         self.lower_boundary = lower_boundary
         self.upper_boundary = upper_boundary
 
+    @override
     def __repr__(self) -> str:
         return f'{type(self).__name__}(lower_boundary={self.lower_boundary!r}, upper_boundary={self.upper_boundary!r})'
 
+    @override
     def contains_datetime(self, dt: datetime, local_timezone: tzinfo | None = None) -> bool:
         """
         Returns `True` if the datetime is contained in the datetime range.
@@ -117,6 +121,7 @@ class DateTimeRange(BaseDateTimeRange):
         # Note: These comparisons will raise TypeErrors when mixing datetimes with and without timezones
         return (lower_datetime is None or dt >= lower_datetime) and (upper_datetime is None or dt <= upper_datetime)
 
+    @override
     def to_dict(self, local_timezone: tzinfo | None = None) -> dict[str, str]:
         """
         Returns a dictionary with string representations of the range boundaries, suitable for the `DateTimeRangeError`
@@ -204,12 +209,14 @@ class DateTimeOffsetRange(BaseDateTimeRange):
         self.offset_minus = offset_minus
         self.offset_plus = offset_plus
 
+    @override
     def __repr__(self) -> str:
         return (
             f'{type(self).__name__}(pivot={self.pivot!r}, offset_minus={self.offset_minus!r}, '
             f'offset_plus={self.offset_plus!r})'
         )
 
+    @override
     def contains_datetime(self, dt: datetime, local_timezone: tzinfo | None = None) -> bool:
         """
         Returns `True` if the datetime is contained in the datetime range.
@@ -223,6 +230,7 @@ class DateTimeOffsetRange(BaseDateTimeRange):
         # Note: These comparisons will raise TypeErrors when mixing datetimes with and without timezones
         return lower_datetime <= dt <= upper_datetime
 
+    @override
     def to_dict(self, local_timezone: tzinfo | None = None) -> dict[str, str]:
         """
         Returns a dictionary with string representations of the range boundaries (calculating `lower_datetime` and

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -6,7 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import TypeAlias, TypeVar
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 __all__ = [
     'UnsetValue',
@@ -33,9 +33,11 @@ class UnsetValueType:
     def __call__(self) -> Self:
         return self
 
+    @override
     def __repr__(self) -> str:
         return 'UnsetValue'
 
+    @override
     def __str__(self) -> str:
         return '<UnsetValue>'
 

--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -48,7 +48,7 @@ class UnsetValueType:
 
 # Create sentinel object and redefine __new__ so that the object cannot be cloned
 UnsetValue = UnsetValueType()
-UnsetValueType.__new__ = lambda cls: UnsetValue  # type: ignore
+UnsetValueType.__new__ = lambda cls: UnsetValue  # type: ignore[assignment, method-assign, return-value]
 
 # Type alias OptionalUnset[T] for fields with DefaultUnset: Allows either the type T or UnsetValue
 OptionalUnset: TypeAlias = T | UnsetValueType

--- a/src/validataclass/validators/allow_empty_string.py
+++ b/src/validataclass/validators/allow_empty_string.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from copy import deepcopy
 from typing import Any, overload
 
-from typing_extensions import Generic, TypeVar
+from typing_extensions import Generic, TypeVar, override
 
 from validataclass.exceptions import InvalidTypeError
 from .validator import Validator
@@ -79,6 +79,7 @@ class AllowEmptyString(
         self.wrapped_validator = validator
         self.default_value = default
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> T_WrappedValidated | T_EmptyStringDefault:
         """
         Validates input data.

--- a/src/validataclass/validators/any_of_validator.py
+++ b/src/validataclass/validators/any_of_validator.py
@@ -8,6 +8,8 @@ import warnings
 from collections.abc import Iterable
 from typing import Any, TypeVar
 
+from typing_extensions import override
+
 from validataclass.exceptions import ValueNotAllowedError, InvalidValidatorOptionException
 from .validator import Validator
 
@@ -125,6 +127,7 @@ class AnyOfValidator(Validator[T_AnyOfValues]):
         # Set case_sensitive parameter, defaulting to False.
         self.case_sensitive = case_sensitive if case_sensitive is not None else False
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> T_AnyOfValues:
         """
         Validate that input is in the list of allowed values. Returns the value (as defined in the list).

--- a/src/validataclass/validators/anything_validator.py
+++ b/src/validataclass/validators/anything_validator.py
@@ -140,9 +140,8 @@ class AnythingValidator(Validator[T_AllowedTypes]):
         """
         Helper method to normalize the `allowed_types` parameter to a unique list that contains only types.
         """
-        # If allowed_types is not already an Iterable, put it in a list. (Treating strings as iterable doesn't make
-        # sense here, so we make an exception for strings to give the user a more meaningful error message.)
-        if not isinstance(allowed_types, Iterable) or isinstance(allowed_types, str):
+        # If allowed_types is not already an Iterable, put it in a list
+        if not isinstance(allowed_types, Iterable):
             allowed_types = [allowed_types]
 
         # Make sure allowed_types only contains valid types (or None, which is replaced later)

--- a/src/validataclass/validators/anything_validator.py
+++ b/src/validataclass/validators/anything_validator.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from collections.abc import Iterable
 from typing import Any, cast, overload
 
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, override
 
 from validataclass.exceptions import InvalidValidatorOptionException
 from .validator import Validator
@@ -164,6 +164,7 @@ class AnythingValidator(Validator[T_AllowedTypes]):
 
         return list(allowed_types_set)
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> T_AllowedTypes:
         """
         Validates input data. Accepts anything (or only specific types) and returns data unmodified.

--- a/src/validataclass/validators/boolean_validator.py
+++ b/src/validataclass/validators/boolean_validator.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import InvalidTypeError
 from .validator import Validator
 
@@ -47,6 +49,7 @@ class BooleanValidator(Validator[bool]):
         """
         self.allow_strings = allow_strings
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> bool:
         """
         Validates type of input data. Returns a boolean.

--- a/src/validataclass/validators/dataclass_validator.py
+++ b/src/validataclass/validators/dataclass_validator.py
@@ -9,6 +9,8 @@ import inspect
 import warnings
 from typing import Any, Callable, TypeGuard, TypeVar
 
+from typing_extensions import override
+
 from validataclass.dataclasses import BaseDefault, NoDefault
 from validataclass.exceptions import (
     DataclassInvalidPreValidateSignatureException,
@@ -236,6 +238,7 @@ class DataclassValidator(Validator[T_Dataclass]):
 
         return validated_dict
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> T_Dataclass:
         """
         Validate an input dictionary according to the specified dataclass. Returns an instance of the dataclass.

--- a/src/validataclass/validators/date_validator.py
+++ b/src/validataclass/validators/date_validator.py
@@ -7,6 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 from datetime import date
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import InvalidDateError
 from .string_validator import StringValidator
 from .validator import Validator
@@ -46,6 +48,7 @@ class DateValidator(Validator[date]):
         # Initialize StringValidator without any parameters
         self.string_validator = StringValidator()
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> date:
         """
         Validates input as a valid date string and convert it to a `datetime.date` object.

--- a/src/validataclass/validators/datetime_validator.py
+++ b/src/validataclass/validators/datetime_validator.py
@@ -9,6 +9,8 @@ from datetime import datetime, tzinfo
 from enum import Enum
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import DateTimeRangeError, InvalidDateTimeError, InvalidValidatorOptionException
 from validataclass.helpers import BaseDateTimeRange
 from .string_validator import StringValidator
@@ -345,6 +347,7 @@ class DateTimeValidator(Validator[datetime]):
         # Precompile regular expression for datetime format
         self.datetime_format_regex = re.compile(self.datetime_format.regex_str)
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> datetime:
         """
         Validates input as a valid datetime string and convert it to a `datetime.datetime` object.

--- a/src/validataclass/validators/decimal_validator.py
+++ b/src/validataclass/validators/decimal_validator.py
@@ -9,6 +9,8 @@ import re
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import (
     DecimalPlacesError,
     InvalidDecimalError,
@@ -149,6 +151,7 @@ class DecimalValidator(Validator[Decimal]):
                 raise InvalidValidatorOptionException('Parameter "output_places" cannot be negative.')
             self.output_quantum = Decimal('0.1') ** output_places
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> Decimal:
         """
         Validates input data as a string, convert it to a `Decimal` object and check optional constraints.

--- a/src/validataclass/validators/dict_validator.py
+++ b/src/validataclass/validators/dict_validator.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any, Generic, TypeVar
 
+from typing_extensions import override
+
 from validataclass.exceptions import (
     DictFieldsValidationError,
     DictInvalidKeyTypeError,
@@ -135,6 +137,7 @@ class DictValidator(Validator[dict[str, T_DictValues]], Generic[T_DictValues]):
         if optional_fields is not None:
             self.required_fields = self.required_fields - set(optional_fields)
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> dict[str, T_DictValues]:
         """
         Validates input data. Returns a validated dict.

--- a/src/validataclass/validators/discard_validator.py
+++ b/src/validataclass/validators/discard_validator.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from copy import deepcopy
 from typing import Any, overload
 
-from typing_extensions import TypeVar
+from typing_extensions import TypeVar, override
 
 from .validator import Validator
 
@@ -66,6 +66,7 @@ class DiscardValidator(Validator[T_DiscardOutput]):
         """
         self.output_value = output_value
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> T_DiscardOutput:
         """
         Validates input data.

--- a/src/validataclass/validators/email_validator.py
+++ b/src/validataclass/validators/email_validator.py
@@ -7,6 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 import re
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import InvalidEmailError
 from validataclass.internal import internet_helpers
 from .string_validator import StringValidator
@@ -88,6 +90,7 @@ class EmailValidator(StringValidator):
         self.allow_empty = allow_empty
         self.to_lowercase = to_lowercase
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> str:
         """
         Validates that input is a valid email address string. Returns unmodified string.

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -97,7 +97,7 @@ class EnumValidator(Validator[T_Enum]):
             `case_insensitive`: DEPRECATED. Validator is case-insensitive by default (see `case_sensitive`)
         """
         # Ensure parameter is an Enum class
-        if not isinstance(enum_cls, type) or not issubclass(enum_cls, Enum):
+        if not issubclass(enum_cls, Enum):
             raise InvalidValidatorOptionException('Parameter "enum_cls" must be an Enum class.')
 
         self.enum_cls = enum_cls

--- a/src/validataclass/validators/enum_validator.py
+++ b/src/validataclass/validators/enum_validator.py
@@ -8,6 +8,8 @@ from collections.abc import Iterable
 from enum import Enum
 from typing import Any, TypeVar
 
+from typing_extensions import override
+
 from validataclass.exceptions import InvalidValidatorOptionException, ValueNotAllowedError
 from .any_of_validator import AnyOfValidator
 from .validator import Validator
@@ -121,6 +123,7 @@ class EnumValidator(Validator[T_Enum]):
             case_insensitive=case_insensitive,
         )
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> T_Enum:
         """
         Validates input to be a valid value of the specified Enum. Returns the Enum member.

--- a/src/validataclass/validators/float_to_decimal_validator.py
+++ b/src/validataclass/validators/float_to_decimal_validator.py
@@ -9,6 +9,8 @@ import math
 from decimal import Decimal
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import NonFiniteNumberError
 from .decimal_validator import DecimalValidator
 
@@ -113,6 +115,7 @@ class FloatToDecimalValidator(DecimalValidator):
         if allow_strings:
             self.allowed_types.append(str)
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> Decimal:
         """
         Validates input data as a float (optionally also as integer or string), then converts it to a `Decimal` object.

--- a/src/validataclass/validators/float_validator.py
+++ b/src/validataclass/validators/float_validator.py
@@ -7,6 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 import math
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import InvalidValidatorOptionException, NumberRangeError, NonFiniteNumberError
 from .validator import Validator
 
@@ -79,6 +81,7 @@ class FloatValidator(Validator[float]):
         self.max_value = float(max_value) if max_value is not None else None
         self.allow_integers = allow_integers
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> float:
         """
         Validates type (and optionally value) of input data. Returns unmodified float.

--- a/src/validataclass/validators/integer_validator.py
+++ b/src/validataclass/validators/integer_validator.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import InvalidIntegerError, InvalidValidatorOptionException, NumberRangeError
 from .validator import Validator
 
@@ -89,6 +91,7 @@ class IntegerValidator(Validator[int]):
         self.max_value = max_value
         self.allow_strings = allow_strings
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> int:
         """
         Validates type (and optionally value) of input data. Returns unmodified integer.

--- a/src/validataclass/validators/list_validator.py
+++ b/src/validataclass/validators/list_validator.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any, Generic, TypeVar
 
+from typing_extensions import override
+
 from validataclass.exceptions import (
     InvalidValidatorOptionException,
     ListItemsValidationError,
@@ -108,6 +110,7 @@ class ListValidator(Validator[list[T_ListItem]], Generic[T_ListItem]):
         self.max_length = max_length
         self.discard_invalid = discard_invalid
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> list[T_ListItem]:
         """
         Validates input data. Returns a validated list.

--- a/src/validataclass/validators/noneable.py
+++ b/src/validataclass/validators/noneable.py
@@ -7,7 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from copy import deepcopy
 from typing import Any, overload
 
-from typing_extensions import Generic, TypeVar
+from typing_extensions import Generic, TypeVar, override
 
 from validataclass.exceptions import InvalidTypeError
 from .validator import Validator
@@ -79,6 +79,7 @@ class Noneable(
         self.wrapped_validator = validator
         self.default_value = default
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> T_WrappedValidated | T_NoneableDefault:
         """
         Validates input data.

--- a/src/validataclass/validators/regex_validator.py
+++ b/src/validataclass/validators/regex_validator.py
@@ -7,6 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 import re
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import RegexMatchError, ValidationError
 from .string_validator import StringValidator
 
@@ -144,6 +146,7 @@ class RegexValidator(StringValidator):
 
         self.allow_empty = allow_empty
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> str:
         """
         Validates input as string and match full string against regular expression.

--- a/src/validataclass/validators/reject_validator.py
+++ b/src/validataclass/validators/reject_validator.py
@@ -6,7 +6,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
-from typing_extensions import Never
+from typing_extensions import Never, override
 
 from validataclass.exceptions import ValidationError, FieldNotAllowedError
 from .validator import Validator
@@ -97,6 +97,7 @@ class RejectValidator(Validator[Never]):
         self.error_code = error_code
         self.error_reason = error_reason
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> Never:
         """
         Validates input data. In this case, reject any value (except for `None` if `allow_none` is set).

--- a/src/validataclass/validators/string_validator.py
+++ b/src/validataclass/validators/string_validator.py
@@ -6,6 +6,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import (
     StringTooShortError,
     StringTooLongError,
@@ -110,6 +112,7 @@ class StringValidator(Validator[str]):
         self.allow_multiline = multiline
         self.unsafe = unsafe
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> str:
         """
         Validates input data to be a valid string, optionally checking length and allowed characters.

--- a/src/validataclass/validators/time_validator.py
+++ b/src/validataclass/validators/time_validator.py
@@ -9,6 +9,8 @@ from datetime import time
 from enum import Enum
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import InvalidTimeError
 from .string_validator import StringValidator
 from .validator import Validator
@@ -98,6 +100,7 @@ class TimeValidator(Validator[time]):
         self.time_format = time_format
         self.time_format_regex = re.compile(self.time_format.regex_str)
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> time:
         """
         Validates input as a valid time string and convert it to a `datetime.time` object.

--- a/src/validataclass/validators/url_validator.py
+++ b/src/validataclass/validators/url_validator.py
@@ -7,6 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 import re
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.exceptions import InvalidUrlError
 from validataclass.internal import internet_helpers
 from .string_validator import StringValidator
@@ -138,6 +140,7 @@ class UrlValidator(StringValidator):
         self.allow_userinfo = allow_userinfo
         self.allow_empty = allow_empty
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> str:
         """
         Validates that input is a valid URL string. Returns unmodified string.

--- a/src/validataclass/validators/validator.py
+++ b/src/validataclass/validators/validator.py
@@ -9,7 +9,7 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Any
 
-from typing_extensions import Generic, TypeVar
+from typing_extensions import Generic, TypeVar, override
 
 from validataclass.exceptions import InvalidTypeError, RequiredValueError
 
@@ -26,6 +26,7 @@ class Validator(Generic[T_Validated], ABC):
     Base class for building extendable validator classes that validate, sanitize and transform input.
     """
 
+    @override
     def __init_subclass__(cls, **kwargs: Any):
         # Check if subclasses are future-proof
         if inspect.getfullargspec(cls.validate).varkw is None:

--- a/tests/mypy/pytest_mypy.ini
+++ b/tests/mypy/pytest_mypy.ini
@@ -8,8 +8,7 @@ strict_equality_for_none = true
 warn_unreachable = true
 enable_error_code =
     deprecated,
-    # TODO: Enable this and fix issues?
-    # explicit-override,
+    explicit-override,
     ignore-without-code,
     # TODO: Maybe enable this is in the future (when we have the mypy plugin)
     # mutable-override,

--- a/tests/mypy/pytest_mypy.ini
+++ b/tests/mypy/pytest_mypy.ini
@@ -3,5 +3,19 @@
 strict = true
 
 # Enable further checks that are not included in strict mode
+disallow_any_unimported = true
+strict_equality_for_none = true
+warn_unreachable = true
 enable_error_code =
-    deprecated
+    deprecated,
+    # TODO: Enable this and fix issues?
+    # explicit-override,
+    ignore-without-code,
+    # TODO: Maybe enable this is in the future (when we have the mypy plugin)
+    # mutable-override,
+    possibly-undefined,
+    redundant-expr,
+    redundant-self,
+    truthy-bool,
+    truthy-iterable,
+    unused-awaitable

--- a/tests/mypy/validators/test_reject_validator.yml
+++ b/tests/mypy/validators/test_reject_validator.yml
@@ -12,12 +12,15 @@
     from validataclass.validators import RejectValidator, Validator
     validator = RejectValidator()
     reveal_type(validator)
-    reveal_type(validator.validate(42))
+    try:
+        reveal_type(validator.validate(42))
+    except:
+        pass
     var1: Validator[Never] = validator  # correct
     var2: Validator[None] = validator   # actually also correct
   out: |
     main:4: note: Revealed type is "validataclass.validators.reject_validator.RejectValidator"
-    main:5: note: Revealed type is "Never"
+    main:6: note: Revealed type is "Never"
 
 # Check that inferred type parameter for a Noneable(RejectValidator) is None and not Never.
 - case: reject_validator_wrapped_in_noneable

--- a/tests/mypy/validators/test_validator.yml
+++ b/tests/mypy/validators/test_validator.yml
@@ -3,9 +3,10 @@
 # Check that mypy complains about subclasses of Validator without type parameter.
 - case: validator_subclass_requires_type_param
   main: |
-    from typing import Any
+    from typing_extensions import Any, override
     from validataclass.validators import Validator
     class TestValidator(Validator):
+        @override
         def validate(self, input_data: Any, **kwargs: Any) -> str:
             return str(input_data)
   out: |
@@ -14,10 +15,11 @@
 # Check that mypy complains when return type of validate method doesn't match Validator type parameter.
 - case: validator_with_incompatible_validate_return_type
   main: |
-    from typing import Any
+    from typing_extensions import Any, override
     from validataclass.validators import Validator
     class TestValidator(Validator[int]):
+        @override
         def validate(self, input_data: Any, **kwargs: Any) -> str:
             return str(input_data)
   out: |
-    main:4: error: Return type "str" of "validate" incompatible with return type "int" in supertype "validataclass.validators.validator.Validator"  [override]
+    main:5: error: Return type "str" of "validate" incompatible with return type "int" in supertype "validataclass.validators.validator.Validator"  [override]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,8 @@ Use of this source code is governed by an MIT-style license that can be found in
 from decimal import Decimal
 from typing import Any
 
+from typing_extensions import override
+
 from validataclass.validators import Validator
 
 
@@ -109,6 +111,7 @@ class UnitTestContextValidator(Validator[str]):
     def __init__(self, *, prefix: str = ''):
         self.prefix = f'[{prefix}] ' if prefix else ''
 
+    @override
     def validate(self, input_data: Any, **kwargs: Any) -> str:
         self._ensure_type(input_data, str)
         return f'{self.prefix}{input_data} / {kwargs}'

--- a/tests/unit/dataclasses/defaults_test.py
+++ b/tests/unit/dataclasses/defaults_test.py
@@ -8,6 +8,7 @@ from copy import copy
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from validataclass.dataclasses import BaseDefault, Default, DefaultFactory, DefaultUnset, NoDefault
 from validataclass.helpers import UnsetValue
@@ -15,9 +16,11 @@ from validataclass.helpers import UnsetValue
 
 # Create a non-abstract subclass of BaseDefault to test methods inherited from BaseDefault
 class ExampleDefaultClass(BaseDefault[int]):
+    @override
     def get_value(self) -> int:
         return 42
 
+    @override
     def needs_factory(self) -> bool:
         return False
 

--- a/tests/unit/dataclasses/validataclass_field_test.py
+++ b/tests/unit/dataclasses/validataclass_field_test.py
@@ -7,9 +7,10 @@ Use of this source code is governed by an MIT-style license that can be found in
 import dataclasses
 
 import pytest
+from typing_extensions import override
 
-from tests.unit.dataclasses._helpers import assert_field_default, assert_field_no_default, get_dataclass_fields
 from tests.test_utils import UNSET_PARAMETER
+from tests.unit.dataclasses._helpers import assert_field_default, assert_field_no_default, get_dataclass_fields
 from validataclass.dataclasses import BaseDefault, Default, DefaultFactory, DefaultUnset, NoDefault, validataclass_field
 from validataclass.helpers import UnsetValue
 from validataclass.validators import IntegerValidator
@@ -110,10 +111,12 @@ class ValidataclassFieldTest:
         class CustomDefault(BaseDefault[int]):
             counter: int = 0
 
+            @override
             def get_value(self) -> int:
                 self.counter += 1
                 return self.counter
 
+            @override
             def needs_factory(self) -> bool:
                 return True
 

--- a/tests/unit/dataclasses/validataclass_test.py
+++ b/tests/unit/dataclasses/validataclass_test.py
@@ -5,6 +5,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 """
 
 import dataclasses
+from dataclasses import FrozenInstanceError
 
 import pytest
 
@@ -77,25 +78,28 @@ class ValidatorDataclassTest:
     def test_validataclass_with_kwargs():
         """ Create a dataclass using @validataclass() with arguments and check that they are passed to @dataclass(). """
 
-        # Create two dataclasses, one without any arguments and one with unsafe_hash=True.
-        # The first won't have a __hash__ function, but the latter will have one.
-        # We can use this to check that the argument was really passed to @dataclass.
+        # As an example, create two dataclasses, one without any arguments and one with frozen=True.
+        # Writing to an object of the frozen dataclass should raise an exception.
 
         @validataclass()
-        class FooDataclass:
+        class NormalDataclass:
             foo: int = IntegerValidator()
 
-        @validataclass(unsafe_hash=True)
-        class BarDataclass:
+        @validataclass(frozen=True)
+        class FrozenDataclass:
             foo: int = IntegerValidator()
 
-        # Check that @validataclass actually created a dataclass (i.e. used @dataclass on the class)
-        assert dataclasses.is_dataclass(FooDataclass)
-        assert dataclasses.is_dataclass(BarDataclass)
+        # NormalDataclass is not frozen, writing is allowed
+        normal = NormalDataclass(foo=42)
+        assert normal.foo == 42
+        normal.foo = 13
+        assert normal.foo == 13
 
-        # Check if __hash__ exists
-        assert FooDataclass.__hash__ is None
-        assert BarDataclass.__hash__ is not None
+        # FrozenDataclass is frozen, writing should raise an exception!
+        frozen = FrozenDataclass(foo=42)
+        assert frozen.foo == 42
+        with pytest.raises(FrozenInstanceError, match="cannot assign to field 'foo'"):
+            frozen.foo = 13  # type: ignore[misc]
 
     @staticmethod
     def test_validataclass_with_tuples():

--- a/tests/unit/validators/anything_validator_test.py
+++ b/tests/unit/validators/anything_validator_test.py
@@ -214,7 +214,7 @@ class AnythingValidatorTest:
         'allowed_types, error_type_repr',
         [
             # Single object that is not a type
-            ('banana', "'banana'"),
+            ('banana', "'b'"),
 
             # Lists/sets that contain something that is not a type
             (['banana'], "'banana'"),

--- a/tests/unit/validators/dataclass_validator_test.py
+++ b/tests/unit/validators/dataclass_validator_test.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from tests.test_utils import UnitTestContextValidator
 from validataclass.dataclasses import Default, DefaultFactory, DefaultUnset, validataclass, validataclass_field
@@ -124,6 +125,7 @@ class UnitTestContextSensitiveDataclassWithPosArgs(UnitTestContextSensitiveDatac
     """
 
     # Same as UnitTestContextSensitiveDataclass, but with positional arguments
+    @override
     def __post_validate__(self, value_required: bool = False) -> None:
         super().__post_validate__(value_required=value_required)
 

--- a/tests/unit/validators/enum_validator_test.py
+++ b/tests/unit/validators/enum_validator_test.py
@@ -438,20 +438,14 @@ class EnumValidatorTest:
     # Invalid validator parameters
 
     @staticmethod
-    @pytest.mark.parametrize(
-        'enum_cls_param',
-        [
-            # Member of an Enum class
-            UnitTestStringEnum.STRAWBERRY,
-
-            # Type that is not an Enum class (anonymous class)
-            type('UnitTestClass', (), {}),
-        ],
-    )
-    def test_enum_cls_invalid(enum_cls_param):
+    def test_enum_cls_invalid():
         """ Check that EnumValidator raises exception when enum_cls is not an Enum. """
+
+        class NotAnEnumClass:
+            pass
+
         with pytest.raises(InvalidValidatorOptionException) as exception_info:
-            EnumValidator(enum_cls_param)  # noqa
+            EnumValidator(NotAnEnumClass)  # type: ignore[type-var]
 
         assert str(exception_info.value) == 'Parameter "enum_cls" must be an Enum class.'
 

--- a/tests/unit/validators/validator_test.py
+++ b/tests/unit/validators/validator_test.py
@@ -7,6 +7,7 @@ Use of this source code is governed by an MIT-style license that can be found in
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from validataclass.validators import Validator
 
@@ -24,6 +25,7 @@ class ValidatorTest:
         # Ensure that Validator creation causes a DeprecationWarning
         with pytest.deprecated_call():
             class ValidatorWithoutKwargs(Validator[Any]):
+                @override
                 def validate(self, input_data: Any) -> Any:  # type: ignore[override]  # noqa
                     return input_data
 


### PR DESCRIPTION
**This is (more or less) part of making validataclass mypy-compatible (#116).**
**Please note that the target branch is `dev-mypy` instead of main.**

---

Did you know that mypy has a bunch of optional rules that are *not* enabled by setting `strict = true`?

This PR enables more strict mypy rules that aren't included in strict mode, and fixes several typing issues that were uncovered by these rules.

None of these changes should affect user code in any breaking way (except that in two cases the error messages when using the library incorrectly look a little bit differently).

### Notes for reviewers

Please don't be scared by the amount of changed files! Many files (almost every validator class) were touched by this PR, but the majority of these changes are a lot of `@override` decorators that have been sprinkled over the code, especially for the `validate()` method in the validator classes. The "explicit-override" fixes were done in a separate commit, so feel free to review the two commits individually.