### PR TITLE
Change UnsetValueType to single-value enum for better type narrowing

### DIFF
--- a/src/validataclass/helpers/unset_value.py
+++ b/src/validataclass/helpers/unset_value.py
@@ -4,7 +4,8 @@ Copyright (c) 2021, binary butterfly GmbH and contributors
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
 """
 
-from typing import TypeAlias, TypeVar
+from enum import Enum
+from typing import Final, Literal, TypeAlias, TypeVar, final
 
 from typing_extensions import Self, override
 
@@ -19,8 +20,16 @@ __all__ = [
 T = TypeVar('T')
 
 
-# Class to create the UnsetValue sentinel object
-class UnsetValueType:
+# Create type for UnsetValue sentinel object as a single-value enum.
+#
+# Using a single-value enum has the advantage that mypy will recognize it as a singleton object and correctly narrow
+# down the type in conditions like `if x is not UnsetValue`.
+#
+# Please also note that while Python 3.15 will finally get a sentinel class (PEP 661), we won't be using that for
+# UnsetValue in the foreseeable future, unless they decide to allow custom boolean evaluation (PEP 661 sentinels are
+# always truthy, but UnsetValue needs to be falsy).
+@final
+class UnsetValueType(Enum):
     """
     Class to represent an unset value (e.g. a field in a dataclass that has no value at all because it did not exist in
     the input data).
@@ -29,6 +38,9 @@ class UnsetValueType:
     `UnsetValue`. There can only be one instance of this class. Attempting to create a new instance of `UnsetValueType`
     or to create a copy of `UnsetValue` will always result in the same instance.
     """
+
+    # Sentinel value
+    UnsetValue = 'UnsetValue'
 
     def __call__(self) -> Self:
         return self
@@ -41,16 +53,15 @@ class UnsetValueType:
     def __str__(self) -> str:
         return '<UnsetValue>'
 
-    def __bool__(self) -> bool:
+    def __bool__(self) -> Literal[False]:
         return False
 
     # Don't define __eq__ because the default implementation is fine (identity check), and because we would then have to
     # implement __hash__ as well, otherwise UnsetValue would be considered mutable by @dataclass.
 
 
-# Create sentinel object and redefine __new__ so that the object cannot be cloned
-UnsetValue = UnsetValueType()
-UnsetValueType.__new__ = lambda cls: UnsetValue  # type: ignore[assignment, method-assign, return-value]
+# Create actual sentinel object
+UnsetValue: Final = UnsetValueType.UnsetValue
 
 # Type alias OptionalUnset[T] for fields with DefaultUnset: Allows either the type T or UnsetValue
 OptionalUnset: TypeAlias = T | UnsetValueType
@@ -60,7 +71,7 @@ OptionalUnsetNone: TypeAlias = T | UnsetValueType | None
 
 
 # Small helper function for easier conversion of UnsetValue to None
-def unset_to_none(value: OptionalUnset[T]) -> T | None:
+def unset_to_none(value: T | UnsetValueType) -> T | None:
     """
     Converts `UnsetValue` to `None`.
 

--- a/tests/mypy/helpers/test_unset_value.yml
+++ b/tests/mypy/helpers/test_unset_value.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Test that a type containing UnsetValueType is narrowed down correctly with `is`, `==` and boolean evaluation.
+- case: unset_value_type_narrowing
+  main: |
+    from validataclass.helpers import UnsetValue, UnsetValueType
+
+    var: str | UnsetValueType
+    reveal_type(var)  # N: Revealed type is "str | validataclass.helpers.unset_value.UnsetValueType"
+
+    # Type narrowing with is
+    if var is not UnsetValue:
+        reveal_type(var)  # N: Revealed type is "str"
+    else:
+        reveal_type(var)  # N: Revealed type is "Literal[validataclass.helpers.unset_value.UnsetValueType.UnsetValue]"
+
+    # Type narrowing with equality
+    if var == UnsetValue:
+        reveal_type(var)  # N: Revealed type is "Literal[validataclass.helpers.unset_value.UnsetValueType.UnsetValue]"
+    else:
+        reveal_type(var)  # N: Revealed type is "str"
+
+    # Type narrowing by checking falsiness
+    if var:
+        reveal_type(var)  # N: Revealed type is "str"
+    else:
+        reveal_type(var)  # N: Revealed type is "Literal[''] | validataclass.helpers.unset_value.UnsetValueType"

--- a/tests/unit/helpers/unset_value_test.py
+++ b/tests/unit/helpers/unset_value_test.py
@@ -27,8 +27,8 @@ class UnsetValueTest:
         """ Test that UnsetValue is a unique sentinel object, i.e. all UnsetValue values are the same. """
         unset_value1 = UnsetValue
         unset_value2 = copy(unset_value1)
-        unset_value3 = UnsetValueType()
-        assert unset_value1 is unset_value2 is unset_value3 is UnsetValue
+        assert unset_value1 is UnsetValue
+        assert unset_value2 is UnsetValue
 
         # Test that calling the UnsetValue returns the UnsetValue itself
         assert UnsetValue() is UnsetValue


### PR DESCRIPTION
This PR changes the `UnsetValueType` class from a regular class to a single-value enum class (and therefore changes `UnsetValue` to be the only member of this enum). This improves type narrowing.

## Explanation

The current approach of how the `UnsetValue` sentinel object is implemented has several drawbacks. The biggest issue for users is that type checkers can't do proper type narrowing on it.

For example, given a variable `foo` of type `str | UnsetValueType`, the following 3 if conditions all work to filter out UnsetValue:

```python
foo: str | UnsetValueType

# Identity check
if foo is not UnsetValue:
    assert isinstance(foo, str)  # foo is always str

# Equality check
if foo != UnsetValue:
    assert isinstance(foo, str)  # foo is always str

# Boolean evaluation
if foo:
    assert isinstance(foo, str)  # foo is always str
    assert len(foo) > 0          # additionally, foo is not an empty string
```

A type checker should be able to recognize this and narrow down the type: Within each of the if blocks, the variable should be treated as a `str`.

However, with the current approach, this does not work: The identity check is not a type check, it only tells us that `var` is not the specific object `UnsetValue`, but from mypy's perspective, it could still be a different object of the type `UnsetValueType`. There's no way for mypy to know that there is only (and can only be) a single instance of the type `UnsetValueType`.

This PR replaces the current approach with a different one: Defining `UnsetValueType` as an enum class that only has a single value `UnsetValueType.UnsetValue` (and defining `UnsetValue` as a short name for the enum member).

This solves the problem, because mypy has some special logic for single-value enums. An enum with only a single value is essentially a singleton class, so mypy knows that `UnsetValue` is the *only* instance of `UnsetValueType`. If a variable is not `UnsetValue`, mypy can infer that the variable cannot be of type `UnsetValueType` either, so type narrowing works as intended.

Additionally, to allow type narrowing in boolean evaluation (the third example), the return type annotation of `UnsetValueType.__bool__` was changed from `bool` to `Literal[False]`, because the class always evaluates as False.

## List of changes

- `UnsetValueType` is now an `Enum` class with the single value `UnsetValueType.UnsetValue`.
- `UnsetValue` is now an alias for `UnsetValueType.UnsetValue`.
- The return type of `UnsetValueType.__bool__` is now `Literal[False]` (instead of `bool`).
- Minor **breaking change**: `UnsetValueType()` now raises an exception instead of returning `UnsetValue`. This is a side effect of the enum implementation, shouldn't affect anyone in practice though.