### PR TITLE
Add new validator: AnyDictValidator

### DIFF
--- a/docs/03-basic-validators.md
+++ b/docs/03-basic-validators.md
@@ -49,6 +49,7 @@ The validators provided by the library can be roughly categorized based on their
   - `Noneable`: Wraps another validator but allows the input to be `None`
   - `NoneToUnsetValue`: Like `Noneable`, but converts `None` to `UnsetValue`
   - `AnythingValidator`: Accepts any input without validation (optionally with type restrictions)
+  - `AnyDictValidator`: Accepts any **dict** with string keys, without validating its values
   - `RejectValidator`: Rejects any input with a validation error (except for `None` if allowed)
   - `DiscardValidator`: Discards any input and returns a predefined value
   - `AllowEmptyString`: Wraps another validator but allows the input to be empty string `('')`
@@ -1192,11 +1193,42 @@ validator.validate('')    # raises InvalidTypeError (with expected_types=['float
 validator.validate(42)    # returns 42
 
 # Accepts only dictionaries (which are returned completely unvalidated!)
+# Please note that this validator accepts dictionaries with any type of keys, unlike the DictValidator which only
+# allows string keys (like in JSON objects). Check out the AnyDictValidator for a similar validator *with* key type
+# validation.
 validator = AnythingValidator(allowed_types=dict)
 validator.validate(None)      # raises RequiredValueError
 validator.validate('')        # raises InvalidTypeError (with expected_type='dict')
 validator.validate({})        # returns {} (empty dictionary)
 validator.validate({13: 12})  # returns {13: 12}
+```
+
+
+### AnyDictValidator
+
+The `AnyDictValidator` is a validator that accepts dictionaries with arbitrary values.
+
+This validator is equivalent to a `DictValidator(default_validator=AnythingValidator())`, so a regular `DictValidator`
+that accepts any field with any value. The only validation that happens here is that **keys have to be strings**, just
+like in the `DictValidator` and just like in JSON objects.
+
+This makes it different from an `AnythingValidator(allowed_types=[dict])`, which allows arbitrary dictionaries with
+arbitrary key types!
+
+In short, if you need a validator for arbitrary dictionaries of the type `dict[str, Any]`, use the `AnyDictValidator()`.
+Only use the `AnythingValidator` if you explicitly want to allow arbitrary key types as well (i.e. `dict[Any, Any]`).
+
+**Examples:**
+
+```python
+from validataclass.validators import AnyDictValidator
+
+# Accepts any dictionary as long as all keys are strings
+validator = AnyDictValidator()
+validator.validate(None)         # raises RequiredValueError
+validator.validate('')           # raises InvalidTypeError (with expected_type='dict')
+validator.validate({})           # returns {} (empty dictionary)
+validator.validate({'foo': 42})  # returns {'foo': 42}
 ```
 
 

--- a/docs/04-lists-and-dicts.md
+++ b/docs/04-lists-and-dicts.md
@@ -278,6 +278,12 @@ except ValidationError as error:
 ```
 
 
+### See also
+
+If you need a validator that accepts dictionaries with arbitrary values, check out the `AnyDictValidator`, which is
+essentially a shorthand for `DictValidator(default_validator=AnythingValidator())`.
+
+
 ## Summary
 
 We have now learned how to validate lists and dictionaries which can contain all sorts of data. This basically is enough to build

--- a/src/validataclass/validators/__init__.py
+++ b/src/validataclass/validators/__init__.py
@@ -9,6 +9,7 @@ from .validator import Validator  # isort:skip
 
 # Validators
 from .allow_empty_string import AllowEmptyString
+from .any_dict_validator import AnyDictValidator
 from .any_of_validator import AnyOfValidator
 from .anything_validator import AnythingValidator
 from .big_integer_validator import BigIntegerValidator
@@ -44,6 +45,7 @@ from .list_validator import T_ListItem  # noqa  # isort:skip
 
 __all__ = [
     'AllowEmptyString',
+    'AnyDictValidator',
     'AnyOfValidator',
     'AnythingValidator',
     'BigIntegerValidator',

--- a/src/validataclass/validators/any_dict_validator.py
+++ b/src/validataclass/validators/any_dict_validator.py
@@ -1,0 +1,40 @@
+"""
+validataclass
+Copyright (c) 2026, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+from .anything_validator import AnythingValidator
+from .dict_validator import DictValidator
+
+__all__ = [
+    'AnyDictValidator',
+]
+
+
+class AnyDictValidator(DictValidator[object]):
+    """
+    Validator that accepts any dictionary, as long as the keys are strings (like the `DictValidator`).
+
+    This is a subclassed `DictValidator` that uses an `AnythingValidator` as the default validator, i.e. it's used for
+    every value in the dictionary. The `AnythingValidator` does no validation and accepts everything.
+
+    Examples:
+
+    ```
+    # Validator that accepts any dictionary with string keys
+    AnyDictValidator()
+    ```
+
+    Valid input: Any `dict[str, object]`
+    Output: Unmodified input dictionary
+    """
+
+    def __init__(self) -> None:
+        """
+        Creates an `AnyDictValidator`.
+        """
+        # Initialize the underlying DictValidator with an AnythingValidator that validates and accepts every field.
+        super().__init__(
+            default_validator=AnythingValidator(),
+        )

--- a/tests/mypy/validators/test_any_dict_validator.yml
+++ b/tests/mypy/validators/test_any_dict_validator.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/typeddjango/pytest-mypy-plugins/master/pytest_mypy_plugins/schema.json
+
+# Check that validator has correct type parameter for Validator[T]
+- case: any_dict_validator
+  main: |
+    from typing import Any
+    from validataclass.validators import AnyDictValidator, DictValidator, Validator
+
+    validator = AnyDictValidator()
+    reveal_type(validator)                       # N: Revealed type is "validataclass.validators.any_dict_validator.AnyDictValidator"
+    reveal_type(validator.validate({'a': 42}))   # N: Revealed type is "dict[str, object]"
+
+    var1: Validator[dict[str, object]] = validator  # correct
+    var2: Validator[dict[str, Any]] = validator     # correct
+    var3: Validator[dict[str, str]] = validator     # E: Incompatible types in assignment (expression has type "AnyDictValidator", variable has type "Validator[dict[str, str]]")  [assignment]
+    var4: Validator[str] = validator                # E: Incompatible types in assignment (expression has type "AnyDictValidator", variable has type "Validator[str]")  [assignment]
+    var5: DictValidator[object] = validator         # correct
+    var6: DictValidator[Any] = validator            # correct
+    var7: DictValidator[str] = validator            # E: Incompatible types in assignment (expression has type "AnyDictValidator", variable has type "DictValidator[str]")  [assignment]

--- a/tests/unit/validators/any_dict_validator_test.py
+++ b/tests/unit/validators/any_dict_validator_test.py
@@ -1,0 +1,86 @@
+"""
+validataclass
+Copyright (c) 2026, binary butterfly GmbH and contributors
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE file.
+"""
+
+import pytest
+
+from validataclass.exceptions import DictInvalidKeyTypeError, InvalidTypeError, RequiredValueError
+from validataclass.validators import AnyDictValidator
+
+
+class AnyDictValidatorTest:
+    """
+    Unit tests for the AnyDictValidator.
+    """
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data',
+        [
+            # Empty dictionary
+            {},
+
+            # Regular dictionary with different value types, also empty string as key (not forbidden)
+            {'foo': 42, 'bar': 'meow', 'baz': None, '': 'empty key'},
+
+            # Nested dictionaries, which *can* have non-string keys because they are not supposed to be validated
+            {'foo': {'a': 42, 'b': 'c'}, 'bar': {1: 42, 2: 'foo'}, 'baz': {}},
+        ],
+    )
+    def test_valid_dicts(input_data):
+        """ Test AnyDictValidator with valid input dictionaries. """
+        validator = AnyDictValidator()
+
+        # Validation should always return the unmodified input dictionary (if valid)
+        assert validator.validate(input_data) == input_data
+
+    @staticmethod
+    def test_invalid_none():
+        """ Check that AnyDictValidator raises exceptions for None as value. """
+        validator = AnyDictValidator()
+
+        with pytest.raises(RequiredValueError) as exception_info:
+            validator.validate(None)
+
+        assert exception_info.value.to_dict() == {
+            'code': 'required_value',
+        }
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'input_data',
+        [
+            True,
+            False,
+            42,
+            'banana',
+            [],
+            ['list'],
+            [{'list': 'of dicts'}],
+        ],
+    )
+    def test_invalid_wrong_type(input_data):
+        """ Check that AnyDictValidator raises exceptions for values that are not of type `dict`. """
+        validator = AnyDictValidator()
+
+        with pytest.raises(InvalidTypeError) as exception_info:
+            validator.validate(input_data)
+
+        assert exception_info.value.to_dict() == {
+            'code': 'invalid_type',
+            'expected_type': 'dict',
+        }
+
+    @staticmethod
+    def test_invalid_key_types():
+        """ Check that AnyDictValidator raises exceptions for dictionaries with non-string keys. """
+        validator = AnyDictValidator()
+
+        with pytest.raises(DictInvalidKeyTypeError) as exception_info:
+            validator.validate({42: 'foo'})
+
+        assert exception_info.value.to_dict() == {
+            'code': 'dict_invalid_key_type',
+        }


### PR DESCRIPTION
This PR adds a new validator, the `AnyDictValidator`. This validator accepts any dictionary without validating its values, as long as the keys are strings (just like in a `DictValidator`).

It's essentially a shorthand for `DictValidator(default_validator=AnythingValidator())`.

Please note that this validator differs from an `AnythingValidator(allowed_types=[dict])`, because the latter does *no* validation on the dictionary at all and therefore allows non-string keys.

Since JSON objects cannot have non-string keys, this doesn't seem to make any difference in practice. However, the `AnyDictValidator` allows for better typing, because it always returns an object of type `dict[str, object]`, while the AnythingValidator returns `dict[Any, Any]`.