### PR TITLE
mypy plugin: Fix cache invalidation for custom validataclass decorators

### DIFF
--- a/docs/07-mypy-plugin.md
+++ b/docs/07-mypy-plugin.md
@@ -75,7 +75,7 @@ defined your own decorator that extends `@validataclass` or you're using another
 
 All these settings require fully qualified names, e.g. `example.module.my_custom_decorator`.
 
-- `custom_validataclass_decorators` (list of strings): Custom decorators for creating validataclasses. 
+- `custom_validataclass_decorators` (list of strings): Custom decorators for creating validataclasses.
   - These are basically treated as aliases to `@validataclass`, so their signature and behaviour should be compatible to
     the original decorator.
   - They are also required to be decorated with `@typing.dataclass_transform(kw_only_default=True)`.
@@ -110,10 +110,14 @@ All error codes are sub codes of `validataclass`, so disabling `validataclass` w
 - `validataclass-empty-type`: Field that has an empty type, i.e. the dataclass can never be validated because the
   validator and default don't allow any value. This can happen when you're using a `RejectValidator` without a default.
   The validator will reject every input, but without a default the field is still required.
-- `validataclass-not-implemented`: Special error code for edge cases that are currently not supported by the plugin.
-  If you get this error, you found an edge case that was unknown to the developers. Please create a bug report for this
-  to help with the plugin development. Even if you believe it was a mistake on your part, you might have found a way to
-  cause an edge case that we thought can never happen.
+
+Additionally, the following error codes likely indicate an issue with the plugin rather than your code. This could be
+an inconsistency in the cache (clearing `.mypy_cache` might help) or an edge case that was unknown to the developers.
+Please create a bug report for these errors to help with plugin development. Even if you believe it was a mistake on
+your part, you might have found a way to cause an edge case that we thought can never happen.
+
+- `validataclass-internal-error`: Internal plugin error, for example because there was an unexpected cache miss.
+- `validataclass-not-implemented`: Error code for edge cases that are currently not supported by the plugin.
 
 
 ## Common mistakes / migration guide

--- a/src/validataclass/mypy/plugin/error_codes.py
+++ b/src/validataclass/mypy/plugin/error_codes.py
@@ -29,6 +29,13 @@ ERROR_CODE_VALIDATACLASS_EMPTY_TYPE: Final = ErrorCode(
     sub_code_of=ERROR_CODE_VALIDATACLASS,
 )
 
+ERROR_CODE_VALIDATACLASS_INTERNAL_ERROR: Final = ErrorCode(
+    'validataclass-internal-error',
+    'Internal error in the validataclass mypy plugin (please create a bug report)',
+    'Plugin',
+    sub_code_of=ERROR_CODE_VALIDATACLASS,
+)
+
 ERROR_CODE_VALIDATACLASS_NOT_IMPLEMENTED: Final = ErrorCode(
     'validataclass-not-implemented',
     'Special code for edge cases that are currently not supported by the plugin (please create a bug report)',

--- a/src/validataclass/mypy/plugin/field_type_resolver.py
+++ b/src/validataclass/mypy/plugin/field_type_resolver.py
@@ -228,7 +228,7 @@ class FieldTypeResolver:
         for base_class in base_classes:
             try:
                 base_parsed_field = self._parsed_field_cache.get_field(base_class, field_name)
-            except KeyError:  # pragma:
+            except KeyError:  # pragma: nocover
                 # A cache miss is most likely a bug in the plugin, so we report it to the user as an internal error
                 self._fail_internal_error(
                     f'Cannot retrieve base class field "{base_class}.{field_name}" from parsed field cache.',

--- a/src/validataclass/mypy/plugin/field_type_resolver.py
+++ b/src/validataclass/mypy/plugin/field_type_resolver.py
@@ -24,7 +24,11 @@ from mypy.types import (
 )
 
 from .constants import FIELD_DEFAULT_BASE_CLASS, VALIDATACLASS_FIELD_FUNCS, VALIDATOR_BASE_CLASS
-from .error_codes import ERROR_CODE_VALIDATACLASS, ERROR_CODE_VALIDATACLASS_EMPTY_TYPE
+from .error_codes import (
+    ERROR_CODE_VALIDATACLASS,
+    ERROR_CODE_VALIDATACLASS_EMPTY_TYPE,
+    ERROR_CODE_VALIDATACLASS_INTERNAL_ERROR,
+)
 from .debug_logger import DebugLogger
 from .parsed_field_cache import ParsedFieldCache, ParsedValidataclassField
 from .plugin_config import PluginConfig
@@ -95,6 +99,24 @@ class FieldTypeResolver:
             msg,
             context or self._ctx.context,
             code=code or ERROR_CODE_VALIDATACLASS,
+        )
+
+    def _fail_internal_error(self, msg: str, note_msg: str, context: Context | None = None) -> None:  # pragma: nocover
+        """
+        Report an internal plugin error using the error code "validataclass-internal-error" as well as a note with more
+        explanation.
+        """
+        context = context or self._ctx.context
+        error_info = self._api.msg.fail(
+            f'Internal plugin error: {msg}',
+            context,
+            code=ERROR_CODE_VALIDATACLASS_INTERNAL_ERROR,
+        )
+        self._api.msg.note(
+            f'{note_msg} If the issue persists, please report this as a bug to: '
+            'https://github.com/binary-butterfly/validataclass/issues',
+            context,
+            parent_error=error_info,
         )
 
     def resolve(self) -> Type:
@@ -204,7 +226,16 @@ class FieldTypeResolver:
 
         # First, retrieve the parsed field of all base classes from our cache, starting with the "oldest" class
         for base_class in base_classes:
-            base_parsed_field = self._parsed_field_cache.get_field(base_class, field_name)
+            try:
+                base_parsed_field = self._parsed_field_cache.get_field(base_class, field_name)
+            except KeyError:  # pragma:
+                # A cache miss is most likely a bug in the plugin, so we report it to the user as an internal error
+                self._fail_internal_error(
+                    f'Cannot retrieve base class field "{base_class}.{field_name}" from parsed field cache.',
+                    'Try removing ".mypy_cache" or use "--no-incremental" to disable the mypy cache as a workaround.',
+                )
+                fully_parsed_field.error = True
+                return fully_parsed_field
 
             # If there was an error when the field in the base class was parsed, set the error flag for later, then
             # ignore the base class and continue.

--- a/src/validataclass/mypy/plugin/plugin.py
+++ b/src/validataclass/mypy/plugin/plugin.py
@@ -58,6 +58,9 @@ class ValidataclassPlugin(Plugin):
     # Set of all validataclass decorators, including the built-in ones and user-defined ones from the plugin config
     _validataclass_decorator_fullnames: set[str]
 
+    # Set of the module names that contain the validataclass decorators from _validataclass_decorator_fullnames
+    _validataclass_decorator_module_names: set[str]
+
     def __init__(self, options: Options):
         super().__init__(options)
 
@@ -71,6 +74,9 @@ class ValidataclassPlugin(Plugin):
         # Cache some values for easier access
         self._validataclass_decorator_fullnames = (
             VALIDATACLASS_DECORATORS | self._plugin_config.custom_validataclass_decorators
+        )
+        self._validataclass_decorator_module_names = set(
+            fullname.rsplit('.', 1)[0] for fullname in self._validataclass_decorator_fullnames
         )
 
     @override
@@ -95,9 +101,9 @@ class ValidataclassPlugin(Plugin):
         TODO: This is a workaround that partially disables caching (which is still better than disabling caching
           completely). We should find a better solution that works without cache invalidation, but for now this is fine.
         """
-        # Always invalidate cache for the module that defines the validataclass decorator to trigger rechecking of all
-        # files that define validataclasses.
-        if ctx.id == 'validataclass.dataclasses.validataclass':
+        # Always invalidate cache for the modules that define the validataclass decorator (as well as custom decorators)
+        # to trigger rechecking of all files that define validataclasses.
+        if ctx.id in self._validataclass_decorator_module_names:
             return str(datetime.now())
 
         return None


### PR DESCRIPTION
The mypy plugin needs an in-memory cache for information about validataclass fields from base classes to analyze sub classes. This means that when analyzing a validataclass, we need to make sure that all base classes are analyzed by the plugin as well, which might not happen because the base class was defined in a different file which is cached by mypy (unrelated to our field cache).

To do this, we enforce rechecking of the module that defines the `@validataclass` decorator. When this module is rechecked, this invalidates the cache for all modules that *use* this decorator to define a validataclass.

This works fine, until we have custom validataclass decorators (`custom_validataclass_decorators` in plugin config). I assumed that those wouldn't be an issue because they usually depend on the `@validataclass` decorator, so their module should be invalidated automatically as well. For some reason, this does not happen (maybe because the `@validataclass` decorator is used in the function body of the custom decorator, while classes are decorated with it?).

This PR hopefully fixes that issue (at least it does in my test case) by extending the cache invalidation workaround to invalidate **all** modules that define validataclass decorators, including custom decorators, instead of just `validataclass.dataclasses.validataclass`.

I also added proper error handling for these cache misses. Previously, the plugin would just crash. Now, if there is a cache miss, it will be reported as a mypy error with the code `validataclass-internal-error`. That way the user will have a regular mypy error, which they maybe cannot fix, but mypy will still analyze the rest of the code without crashing. The error also contains a note with a workaround (`--no-incremental`, which disables the mypy cache) and asks the user to please report the error if it persists.